### PR TITLE
Added example of sorting for mapper-reducer issue

### DIFF
--- a/mapper_reducer_sorter_problem/data_generator/random_number_generator.go
+++ b/mapper_reducer_sorter_problem/data_generator/random_number_generator.go
@@ -1,0 +1,23 @@
+package data_generator
+
+import (
+	"math/rand"
+)
+
+type RandomGenerator struct {
+	seedValue int
+}
+
+func NewRandomNumberGenerator(seed int) *RandomGenerator {
+	if seed < 0 {
+		seed = rand.Int()
+	}
+	rand.Seed(int64(seed))
+	return &RandomGenerator{
+		seedValue: seed,
+	}
+}
+
+func (generator *RandomGenerator) GenerateRandomInt() int {
+	return rand.Int()
+}

--- a/mapper_reducer_sorter_problem/main.go
+++ b/mapper_reducer_sorter_problem/main.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"concurrency_problems/mapper_reducer_sorter_problem/data_generator"
+	"concurrency_problems/mapper_reducer_sorter_problem/storage"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	MAX_CONCURRENT_WRITER                              = 1000
+	MAX_RANDOM_NUMBER_GENERATION_PER_INTERMEDIATE_FILE = 50000
+	RANDOM_NUM_GENERATORS                              = 1000
+
+	OPERATIONAL_DIR                 = "operations"
+	UNSORTED_INITIAL_FILE_PREFIX    = "random_data_generated_"
+	SORTED_INTERMEDIATE_FILE_PREFIX = "intermediate_sorted_data_"
+	SORTED_FINAL_FILE_PREFIX        = "final_sorted_data"
+	FILE_EXTENSION                  = ".txt"
+)
+
+var concurrentWriterSemaphore *semaphore.Weighted
+var calculationMutex sync.Mutex
+var totalInitialRandomNumberGenerated = 0
+var totalEntriesInFinalSortedFile = 0
+
+func main() {
+	//fmt.Println("hello!")
+	// testReadFile()
+	concurrentWriterSemaphore = semaphore.NewWeighted(int64(MAX_CONCURRENT_WRITER))
+	timeFormat := time.RFC3339
+	startTime := time.Now()
+
+	var SEED_VALUE int = -1
+	generator := data_generator.NewRandomNumberGenerator(SEED_VALUE)
+	var wGroup sync.WaitGroup
+
+	dir, _ := os.Getwd()
+	location := dir + "\\" + OPERATIONAL_DIR
+	os.RemoveAll(location)
+	os.Mkdir(location, 0777)
+
+	// Part 1: Generate random numbers and store in file in unsorted way
+	log.Print("------- Part 1: Generating random numbers -------")
+	for i := 0; i < RANDOM_NUM_GENERATORS; i++ {
+		wGroup.Add(1)
+		go fileWriterWithRandomNum(generator, i, &wGroup)
+	}
+	wGroup.Wait()
+	log.Print("Initial random numbers generated: ", totalInitialRandomNumberGenerated)
+
+	// Part 2: Mapper: Sort the content of individual files
+	log.Print("------- Part 2: Mapper intermediate sorter -------")
+	for i := 0; i < RANDOM_NUM_GENERATORS; i++ {
+		wGroup.Add(1)
+		go intermediateSorterIndividualFile(i, &wGroup)
+	}
+	wGroup.Wait()
+
+	// Part 3: Reducer: Capture and sort all the intermediate files in a streaming manner
+	log.Print("------- Part 3: Reducer final sorter -------")
+	finalSorter()
+	log.Print("------- Completed -------")
+
+	endTime := time.Now()
+	fmt.Println("Execution started at: ", startTime.Format(timeFormat))
+	fmt.Println("Execution ended at: ", endTime.Format(timeFormat))
+	fmt.Println("Execution duration: ", endTime.Sub(startTime))
+	fmt.Println("Initial random numbers generated: ", totalInitialRandomNumberGenerated)
+	fmt.Println("Total entries at final sorted file: ", totalEntriesInFinalSortedFile)
+}
+
+/*
+	Learnings:
+		1. Always convert the integer to string using strconv.Itoa()
+		2. What is range??
+*/
+
+func fileWriterWithRandomNum(generator *data_generator.RandomGenerator, index int, wGroup *sync.WaitGroup) {
+	concurrentWriterSemaphore.Acquire(context.Background(), 1)
+	defer concurrentWriterSemaphore.Release(1)
+	defer wGroup.Done()
+	log.Printf("Initiating random data generation for index: %d", index)
+	count := generator.GenerateRandomInt() % MAX_RANDOM_NUMBER_GENERATION_PER_INTERMEDIATE_FILE
+	log.Printf("Generating %d numbers for index: %d", count, index)
+	calculationMutex.Lock()
+	totalInitialRandomNumberGenerated += count
+	calculationMutex.Unlock()
+	var content strings.Builder
+	for i := 0; i < count; i++ {
+		content.WriteString(strconv.Itoa(generator.GenerateRandomInt()) + "\n")
+	}
+
+	// TODO: Handle directory structure in OS-agnostic way
+	dir, _ := os.Getwd()
+	fileName := dir + "\\" + OPERATIONAL_DIR + "\\" + UNSORTED_INITIAL_FILE_PREFIX + strconv.Itoa(index) + FILE_EXTENSION
+	log.Printf("Storing the random data generated to file %s for index: %d", fileName, index)
+	var file storage.File
+	file = storage.NewFileSystem(fileName)
+	err := file.Write(0, content.String())
+	file.Close()
+	if err != nil {
+		log.Printf("Error occurred while writing content to file %s: %s", fileName, err)
+	}
+}
+
+// TODO: use semaphore to restrict concurrent operations
+func intermediateSorterIndividualFile(index int, wGroup *sync.WaitGroup) {
+	concurrentWriterSemaphore.Acquire(context.Background(), 1)
+	defer concurrentWriterSemaphore.Release(1)
+	defer wGroup.Done()
+
+	// Step 01: Read the content from the unsorted file
+	dir, _ := os.Getwd()
+	intermediateUnsortedFilename := dir + "\\" + OPERATIONAL_DIR + "\\" + UNSORTED_INITIAL_FILE_PREFIX + strconv.Itoa(index) + FILE_EXTENSION
+	log.Printf("Reading the intermediate file %s for index: %d", intermediateUnsortedFilename, index)
+	var file storage.File
+	file = storage.NewFileSystem(intermediateUnsortedFilename)
+	content, err := file.Read(-1, -1)
+	file.Close()
+	if err != nil {
+		log.Printf("Error occurred while reading content from file %s: %s",
+			intermediateUnsortedFilename, err)
+	}
+
+	// Step 02: Convert the content to int array and sort
+	log.Printf("Converting and sorting the data read from file %s for index: %d",
+		intermediateUnsortedFilename, index)
+	contents := strings.Split(content, "\n")
+	var array []int
+	for _, value := range contents {
+		intValue, err := strconv.Atoi(value)
+		if err == nil {
+			array = append(array, intValue)
+		}
+	}
+	sort.Ints(array)
+	contents = make([]string, 0)
+	content = ""
+
+	var outputContent strings.Builder
+	for _, value := range array {
+		outputContent.WriteString(strconv.Itoa(value) + "\n")
+	}
+
+	// Step 03: Write the sorted content to intermediate sorted file
+	outputFilename := dir + "\\" + OPERATIONAL_DIR + "\\" + SORTED_INTERMEDIATE_FILE_PREFIX + strconv.Itoa(index) + FILE_EXTENSION
+	log.Printf("Storing the sorted data to file %s for index: %d", outputFilename, index)
+	file = storage.NewFileSystem(outputFilename)
+	err = file.Write(0, outputContent.String())
+	file.Close()
+	if err != nil {
+		log.Printf("Error occurred while storing the sorted content to file %s for index: %d",
+			outputFilename, index)
+	}
+}
+
+func finalSorter() {
+	log.Print("Initializing the cursor for all the intermediate sorted files")
+	var files []storage.File
+	dir, _ := os.Getwd()
+	for i := 0; i < RANDOM_NUM_GENERATORS; i++ {
+		intermediateSortedFilename := dir + "\\" + OPERATIONAL_DIR + "\\" + SORTED_INTERMEDIATE_FILE_PREFIX + strconv.Itoa(i) + FILE_EXTENSION
+		files = append(files, storage.NewFileSystem(intermediateSortedFilename))
+	}
+
+	// Set initial cursor for all the files
+	var array [RANDOM_NUM_GENERATORS]string
+	for i := 0; i < RANDOM_NUM_GENERATORS; i++ {
+		str, _ := files[i].ReadNextLine(-1, -1)
+		array[i] = str
+	}
+
+	fmt.Println(array)
+
+	finalOutputFileName := dir + "\\" + OPERATIONAL_DIR + "\\" + SORTED_FINAL_FILE_PREFIX + FILE_EXTENSION
+	os.Remove(finalOutputFileName)
+	var finalOutputFile storage.File
+	finalOutputFile = storage.NewFileSystem(finalOutputFileName)
+
+	log.Print("Initiating the streaming merge sort operation on all the opened file")
+	var iteration = 0
+	for {
+		iteration++
+		// Find the smallest element and increase corresponding cursor
+		var indexWithMinValue int = -1
+		var currentMinValue = 0
+		for i := 0; i < RANDOM_NUM_GENERATORS; i++ {
+			if array[i] != "" && indexWithMinValue == -1 {
+				indexWithMinValue = i
+				value, _ := strconv.Atoi(array[i])
+				currentMinValue = value
+			}
+			if indexWithMinValue != -1 && array[i] != "" {
+				value, _ := strconv.Atoi(array[i])
+				if value < currentMinValue {
+					indexWithMinValue = i
+					currentMinValue = value
+				}
+			}
+		}
+		// log.Printf("01 Iteration:%d Smallest Element:%d Index:%d", iteration, currentMinValue, indexWithMinValue)
+
+		if indexWithMinValue == -1 {
+			// Termination condition
+			break
+		} else {
+			// Append it to the final sorted file
+			finalOutputFile.Append(strconv.Itoa(currentMinValue) + "\n")
+
+			// Increase the cursor of the minimal index
+			str, _ := files[indexWithMinValue].ReadNextLine(-1, -1)
+			array[indexWithMinValue] = str
+		}
+
+		// log.Printf("02 Iteration:%d Smallest Element:%d Index:%d", iteration, currentMinValue, indexWithMinValue)
+	}
+	totalEntriesInFinalSortedFile = iteration - 1
+
+	// Close the files
+	err := finalOutputFile.Close()
+	if err != nil {
+		log.Print("Error occurred while closing file %s: %s", finalOutputFileName, err)
+	}
+	for i := 0; i < RANDOM_NUM_GENERATORS; i++ {
+		err := files[i].Close()
+		if err != nil {
+			log.Print("Error occurred while closing file for index %d: %s", i, err)
+		}
+	}
+}
+
+func testReadFile() {
+	dir, _ := os.Getwd()
+	intermediateSortedFilename := dir + "\\" + OPERATIONAL_DIR + "\\" + SORTED_INTERMEDIATE_FILE_PREFIX + "5" + FILE_EXTENSION
+	file := storage.NewFileSystem(intermediateSortedFilename)
+	fmt.Println(intermediateSortedFilename)
+	for {
+		var str string
+		str, _ = file.ReadNextLine(-1, -1)
+		if str == "" {
+			break
+		}
+		fmt.Println(str)
+		time.Sleep(time.Second)
+	}
+}

--- a/mapper_reducer_sorter_problem/output_large.txt
+++ b/mapper_reducer_sorter_problem/output_large.txt
@@ -1,0 +1,6013 @@
+2024/05/19 23:42:24 ------- Part 1: Generating random numbers -------
+2024/05/19 23:42:24 Initiating random data generation for index: 2
+2024/05/19 23:42:24 Generating 41142 numbers for index: 2
+2024/05/19 23:42:24 Initiating random data generation for index: 6
+2024/05/19 23:42:24 Generating 48094 numbers for index: 6
+2024/05/19 23:42:24 Initiating random data generation for index: 3
+2024/05/19 23:42:24 Generating 21720 numbers for index: 3
+2024/05/19 23:42:24 Initiating random data generation for index: 0
+2024/05/19 23:42:24 Generating 48448 numbers for index: 0
+2024/05/19 23:42:24 Initiating random data generation for index: 67
+2024/05/19 23:42:24 Initiating random data generation for index: 1
+2024/05/19 23:42:24 Initiating random data generation for index: 16
+2024/05/19 23:42:24 Generating 41800 numbers for index: 16
+2024/05/19 23:42:24 Generating 10313 numbers for index: 1
+2024/05/19 23:42:24 Initiating random data generation for index: 7
+2024/05/19 23:42:24 Generating 8842 numbers for index: 7
+2024/05/19 23:42:24 Initiating random data generation for index: 8
+2024/05/19 23:42:24 Generating 4808 numbers for index: 8
+2024/05/19 23:42:24 Initiating random data generation for index: 9
+2024/05/19 23:42:24 Generating 11323 numbers for index: 9
+2024/05/19 23:42:24 Initiating random data generation for index: 42
+2024/05/19 23:42:24 Generating 28904 numbers for index: 42
+2024/05/19 23:42:24 Initiating random data generation for index: 43
+2024/05/19 23:42:24 Generating 4174 numbers for index: 43
+2024/05/19 23:42:24 Initiating random data generation for index: 44
+2024/05/19 23:42:24 Initiating random data generation for index: 41
+2024/05/19 23:42:24 Initiating random data generation for index: 57
+2024/05/19 23:42:24 Generating 15829 numbers for index: 41
+2024/05/19 23:42:24 Initiating random data generation for index: 63
+2024/05/19 23:42:24 Initiating random data generation for index: 64
+2024/05/19 23:42:24 Generating 16841 numbers for index: 64
+2024/05/19 23:42:24 Initiating random data generation for index: 65
+2024/05/19 23:42:24 Generating 30769 numbers for index: 65
+2024/05/19 23:42:24 Initiating random data generation for index: 66
+2024/05/19 23:42:24 Initiating random data generation for index: 58
+2024/05/19 23:42:24 Generating 37025 numbers for index: 58
+2024/05/19 23:42:24 Initiating random data generation for index: 89
+2024/05/19 23:42:24 Generating 525 numbers for index: 89
+2024/05/19 23:42:24 Initiating random data generation for index: 68
+2024/05/19 23:42:24 Generating 45455 numbers for index: 68
+2024/05/19 23:42:24 Initiating random data generation for index: 30
+2024/05/19 23:42:24 Generating 22806 numbers for index: 30
+2024/05/19 23:42:24 Initiating random data generation for index: 31
+2024/05/19 23:42:24 Initiating random data generation for index: 78
+2024/05/19 23:42:24 Initiating random data generation for index: 11
+2024/05/19 23:42:24 Initiating random data generation for index: 74
+2024/05/19 23:42:24 Generating 5142 numbers for index: 74
+2024/05/19 23:42:24 Initiating random data generation for index: 79
+2024/05/19 23:42:24 Initiating random data generation for index: 102
+2024/05/19 23:42:24 Initiating random data generation for index: 82
+2024/05/19 23:42:24 Initiating random data generation for index: 105
+2024/05/19 23:42:24 Initiating random data generation for index: 83
+2024/05/19 23:42:24 Initiating random data generation for index: 124
+2024/05/19 23:42:24 Generating 12977 numbers for index: 124
+2024/05/19 23:42:24 Initiating random data generation for index: 128
+2024/05/19 23:42:24 Initiating random data generation for index: 135
+2024/05/19 23:42:24 Generating 34881 numbers for index: 63
+2024/05/19 23:42:24 Initiating random data generation for index: 137
+2024/05/19 23:42:24 Initiating random data generation for index: 138
+2024/05/19 23:42:24 Initiating random data generation for index: 140
+2024/05/19 23:42:24 Generating 40691 numbers for index: 140
+2024/05/19 23:42:24 Initiating random data generation for index: 130
+2024/05/19 23:42:24 Initiating random data generation for index: 114
+2024/05/19 23:42:24 Generating 41763 numbers for index: 130
+2024/05/19 23:42:24 Generating 2616 numbers for index: 82
+2024/05/19 23:42:24 Generating 5565 numbers for index: 114
+2024/05/19 23:42:24 Generating 7754 numbers for index: 79
+2024/05/19 23:42:24 Generating 34770 numbers for index: 44
+2024/05/19 23:42:24 Generating 40366 numbers for index: 11
+2024/05/19 23:42:24 Initiating random data generation for index: 143
+2024/05/19 23:42:24 Initiating random data generation for index: 146
+2024/05/19 23:42:24 Initiating random data generation for index: 149
+2024/05/19 23:42:24 Initiating random data generation for index: 151
+2024/05/19 23:42:24 Generating 30792 numbers for index: 151
+2024/05/19 23:42:24 Initiating random data generation for index: 152
+2024/05/19 23:42:24 Generating 357 numbers for index: 152
+2024/05/19 23:42:24 Initiating random data generation for index: 153
+2024/05/19 23:42:24 Initiating random data generation for index: 154
+2024/05/19 23:42:24 Initiating random data generation for index: 157
+2024/05/19 23:42:24 Generating 10450 numbers for index: 157
+2024/05/19 23:42:24 Initiating random data generation for index: 14
+2024/05/19 23:42:24 Initiating random data generation for index: 15
+2024/05/19 23:42:24 Initiating random data generation for index: 4
+2024/05/19 23:42:24 Generating 43740 numbers for index: 67
+2024/05/19 23:42:24 Initiating random data generation for index: 5
+2024/05/19 23:42:24 Initiating random data generation for index: 45
+2024/05/19 23:42:24 Initiating random data generation for index: 46
+2024/05/19 23:42:24 Initiating random data generation for index: 47
+2024/05/19 23:42:24 Initiating random data generation for index: 48
+2024/05/19 23:42:24 Initiating random data generation for index: 49
+2024/05/19 23:42:24 Initiating random data generation for index: 50
+2024/05/19 23:42:24 Generating 47793 numbers for index: 49
+2024/05/19 23:42:24 Initiating random data generation for index: 52
+2024/05/19 23:42:24 Initiating random data generation for index: 170
+2024/05/19 23:42:24 Generating 7902 numbers for index: 170
+2024/05/19 23:42:24 Initiating random data generation for index: 53
+2024/05/19 23:42:24 Initiating random data generation for index: 54
+2024/05/19 23:42:24 Initiating random data generation for index: 55
+2024/05/19 23:42:24 Initiating random data generation for index: 56
+2024/05/19 23:42:24 Initiating random data generation for index: 59
+2024/05/19 23:42:24 Initiating random data generation for index: 180
+2024/05/19 23:42:24 Generating 8456 numbers for index: 180
+2024/05/19 23:42:24 Initiating random data generation for index: 182
+2024/05/19 23:42:24 Initiating random data generation for index: 185
+2024/05/19 23:42:24 Initiating random data generation for index: 189
+2024/05/19 23:42:24 Initiating random data generation for index: 61
+2024/05/19 23:42:24 Initiating random data generation for index: 62
+2024/05/19 23:42:24 Generating 10443 numbers for index: 66
+2024/05/19 23:42:24 Initiating random data generation for index: 10
+2024/05/19 23:42:24 Generating 30456 numbers for index: 31
+2024/05/19 23:42:24 Initiating random data generation for index: 12
+2024/05/19 23:42:24 Initiating random data generation for index: 32
+2024/05/19 23:42:24 Initiating random data generation for index: 33
+2024/05/19 23:42:24 Initiating random data generation for index: 34
+2024/05/19 23:42:24 Initiating random data generation for index: 35
+2024/05/19 23:42:24 Initiating random data generation for index: 36
+2024/05/19 23:42:24 Initiating random data generation for index: 37
+2024/05/19 23:42:24 Initiating random data generation for index: 38
+2024/05/19 23:42:24 Initiating random data generation for index: 39
+2024/05/19 23:42:24 Initiating random data generation for index: 40
+2024/05/19 23:42:24 Generating 33714 numbers for index: 78
+2024/05/19 23:42:24 Initiating random data generation for index: 69
+2024/05/19 23:42:24 Initiating random data generation for index: 70
+2024/05/19 23:42:24 Initiating random data generation for index: 71
+2024/05/19 23:42:24 Initiating random data generation for index: 194
+2024/05/19 23:42:24 Generating 22215 numbers for index: 62
+2024/05/19 23:42:24 Initiating random data generation for index: 29
+2024/05/19 23:42:24 Initiating random data generation for index: 203
+2024/05/19 23:42:24 Generating 23611 numbers for index: 52
+2024/05/19 23:42:24 Initiating random data generation for index: 23
+2024/05/19 23:42:24 Initiating random data generation for index: 196
+2024/05/19 23:42:24 Generating 46981 numbers for index: 194
+2024/05/19 23:42:24 Generating 30814 numbers for index: 35
+2024/05/19 23:42:24 Generating 34535 numbers for index: 71
+2024/05/19 23:42:24 Generating 8058 numbers for index: 10
+2024/05/19 23:42:24 Initiating random data generation for index: 204
+2024/05/19 23:42:24 Generating 18814 numbers for index: 33
+2024/05/19 23:42:24 Initiating random data generation for index: 221
+2024/05/19 23:42:24 Initiating random data generation for index: 233
+2024/05/19 23:42:24 Generating 37422 numbers for index: 233
+2024/05/19 23:42:24 Initiating random data generation for index: 205
+2024/05/19 23:42:24 Generating 31597 numbers for index: 205
+2024/05/19 23:42:24 Initiating random data generation for index: 256
+2024/05/19 23:42:24 Generating 46364 numbers for index: 23
+2024/05/19 23:42:24 Initiating random data generation for index: 240
+2024/05/19 23:42:24 Generating 37120 numbers for index: 29
+2024/05/19 23:42:24 Initiating random data generation for index: 209
+2024/05/19 23:42:24 Initiating random data generation for index: 216
+2024/05/19 23:42:24 Initiating random data generation for index: 255
+2024/05/19 23:42:24 Generating 17119 numbers for index: 255
+2024/05/19 23:42:24 Initiating random data generation for index: 212
+2024/05/19 23:42:24 Initiating random data generation for index: 220
+2024/05/19 23:42:24 Generating 22482 numbers for index: 220
+2024/05/19 23:42:24 Generating 19357 numbers for index: 204
+2024/05/19 23:42:24 Initiating random data generation for index: 200
+2024/05/19 23:42:24 Generating 41546 numbers for index: 200
+2024/05/19 23:42:24 Initiating random data generation for index: 226
+2024/05/19 23:42:24 Generating 19980 numbers for index: 226
+2024/05/19 23:42:24 Generating 6948 numbers for index: 203
+2024/05/19 23:42:24 Initiating random data generation for index: 77
+2024/05/19 23:42:24 Generating 4159 numbers for index: 77
+2024/05/19 23:42:24 Initiating random data generation for index: 22
+2024/05/19 23:42:24 Initiating random data generation for index: 76
+2024/05/19 23:42:24 Generating 26425 numbers for index: 76
+2024/05/19 23:42:24 Initiating random data generation for index: 18
+2024/05/19 23:42:24 Initiating random data generation for index: 19
+2024/05/19 23:42:24 Generating 6220 numbers for index: 19
+2024/05/19 23:42:24 Initiating random data generation for index: 257
+2024/05/19 23:42:24 Initiating random data generation for index: 268
+2024/05/19 23:42:24 Initiating random data generation for index: 284
+2024/05/19 23:42:24 Initiating random data generation for index: 272
+2024/05/19 23:42:24 Initiating random data generation for index: 287
+2024/05/19 23:42:24 Initiating random data generation for index: 289
+2024/05/19 23:42:24 Initiating random data generation for index: 303
+2024/05/19 23:42:24 Initiating random data generation for index: 290
+2024/05/19 23:42:24 Initiating random data generation for index: 324
+2024/05/19 23:42:24 Initiating random data generation for index: 333
+2024/05/19 23:42:24 Initiating random data generation for index: 326
+2024/05/19 23:42:24 Initiating random data generation for index: 341
+2024/05/19 23:42:24 Initiating random data generation for index: 355
+2024/05/19 23:42:24 Initiating random data generation for index: 357
+2024/05/19 23:42:24 Initiating random data generation for index: 356
+2024/05/19 23:42:24 Initiating random data generation for index: 364
+2024/05/19 23:42:24 Initiating random data generation for index: 368
+2024/05/19 23:42:24 Initiating random data generation for index: 370
+2024/05/19 23:42:24 Initiating random data generation for index: 377
+2024/05/19 23:42:24 Initiating random data generation for index: 381
+2024/05/19 23:42:24 Initiating random data generation for index: 391
+2024/05/19 23:42:24 Generating 40004 numbers for index: 391
+2024/05/19 23:42:24 Initiating random data generation for index: 297
+2024/05/19 23:42:24 Generating 23006 numbers for index: 297
+2024/05/19 23:42:24 Generating 39036 numbers for index: 381
+2024/05/19 23:42:24 Initiating random data generation for index: 349
+2024/05/19 23:42:24 Initiating random data generation for index: 278
+2024/05/19 23:42:24 Generating 21043 numbers for index: 278
+2024/05/19 23:42:24 Initiating random data generation for index: 392
+2024/05/19 23:42:24 Initiating random data generation for index: 393
+2024/05/19 23:42:24 Generating 32400 numbers for index: 393
+2024/05/19 23:42:24 Initiating random data generation for index: 394
+2024/05/19 23:42:24 Generating 15129 numbers for index: 394
+2024/05/19 23:42:24 Initiating random data generation for index: 395
+2024/05/19 23:42:24 Generating 41619 numbers for index: 395
+2024/05/19 23:42:24 Initiating random data generation for index: 396
+2024/05/19 23:42:24 Initiating random data generation for index: 397
+2024/05/19 23:42:24 Generating 31629 numbers for index: 397
+2024/05/19 23:42:24 Initiating random data generation for index: 398
+2024/05/19 23:42:24 Initiating random data generation for index: 399
+2024/05/19 23:42:24 Generating 21811 numbers for index: 399
+2024/05/19 23:42:24 Initiating random data generation for index: 435
+2024/05/19 23:42:24 Initiating random data generation for index: 441
+2024/05/19 23:42:24 Generating 28268 numbers for index: 435
+2024/05/19 23:42:24 Initiating random data generation for index: 443
+2024/05/19 23:42:24 Initiating random data generation for index: 401
+2024/05/19 23:42:24 Generating 2619 numbers for index: 401
+2024/05/19 23:42:24 Initiating random data generation for index: 444
+2024/05/19 23:42:24 Generating 38743 numbers for index: 444
+2024/05/19 23:42:24 Initiating random data generation for index: 445
+2024/05/19 23:42:24 Generating 45764 numbers for index: 445
+2024/05/19 23:42:24 Initiating random data generation for index: 446
+2024/05/19 23:42:24 Generating 13803 numbers for index: 446
+2024/05/19 23:42:24 Initiating random data generation for index: 447
+2024/05/19 23:42:24 Initiating random data generation for index: 448
+2024/05/19 23:42:24 Generating 12991 numbers for index: 448
+2024/05/19 23:42:24 Initiating random data generation for index: 564
+2024/05/19 23:42:24 Initiating random data generation for index: 463
+2024/05/19 23:42:24 Initiating random data generation for index: 409
+2024/05/19 23:42:24 Initiating random data generation for index: 469
+2024/05/19 23:42:24 Initiating random data generation for index: 412
+2024/05/19 23:42:24 Generating 29241 numbers for index: 412
+2024/05/19 23:42:24 Initiating random data generation for index: 473
+2024/05/19 23:42:24 Initiating random data generation for index: 416
+2024/05/19 23:42:24 Generating 43574 numbers for index: 416
+2024/05/19 23:42:24 Initiating random data generation for index: 524
+2024/05/19 23:42:24 Initiating random data generation for index: 502
+2024/05/19 23:42:24 Generating 8876 numbers for index: 502
+2024/05/19 23:42:24 Initiating random data generation for index: 482
+2024/05/19 23:42:24 Generating 21914 numbers for index: 482
+2024/05/19 23:42:24 Initiating random data generation for index: 483
+2024/05/19 23:42:24 Generating 37257 numbers for index: 483
+2024/05/19 23:42:24 Initiating random data generation for index: 484
+2024/05/19 23:42:24 Initiating random data generation for index: 485
+2024/05/19 23:42:24 Generating 44396 numbers for index: 485
+2024/05/19 23:42:24 Initiating random data generation for index: 481
+2024/05/19 23:42:24 Generating 20738 numbers for index: 481
+2024/05/19 23:42:24 Initiating random data generation for index: 503
+2024/05/19 23:42:24 Initiating random data generation for index: 486
+2024/05/19 23:42:24 Initiating random data generation for index: 510
+2024/05/19 23:42:24 Generating 30914 numbers for index: 510
+2024/05/19 23:42:24 Initiating random data generation for index: 525
+2024/05/19 23:42:24 Initiating random data generation for index: 530
+2024/05/19 23:42:24 Generating 42659 numbers for index: 530
+2024/05/19 23:42:24 Generating 21936 numbers for index: 525
+2024/05/19 23:42:24 Initiating random data generation for index: 511
+2024/05/19 23:42:24 Generating 36003 numbers for index: 511
+2024/05/19 23:42:24 Generating 15868 numbers for index: 484
+2024/05/19 23:42:24 Initiating random data generation for index: 538
+2024/05/19 23:42:24 Initiating random data generation for index: 523
+2024/05/19 23:42:24 Initiating random data generation for index: 543
+2024/05/19 23:42:24 Initiating random data generation for index: 434
+2024/05/19 23:42:24 Generating 22629 numbers for index: 434
+2024/05/19 23:42:24 Generating 39598 numbers for index: 503
+2024/05/19 23:42:24 Generating 2336 numbers for index: 486
+2024/05/19 23:42:24 Initiating random data generation for index: 488
+2024/05/19 23:42:24 Generating 15585 numbers for index: 441
+2024/05/19 23:42:24 Initiating random data generation for index: 493
+2024/05/19 23:42:24 Generating 45206 numbers for index: 493
+2024/05/19 23:42:24 Initiating random data generation for index: 558
+2024/05/19 23:42:24 Generating 25455 numbers for index: 558
+2024/05/19 23:42:24 Initiating random data generation for index: 563
+2024/05/19 23:42:24 Initiating random data generation for index: 559
+2024/05/19 23:42:24 Generating 39940 numbers for index: 303
+2024/05/19 23:42:24 Generating 36184 numbers for index: 443
+2024/05/19 23:42:24 Initiating random data generation for index: 512
+2024/05/19 23:42:24 Generating 1275 numbers for index: 512
+2024/05/19 23:42:24 Generating 37291 numbers for index: 543
+2024/05/19 23:42:24 Initiating random data generation for index: 420
+2024/05/19 23:42:24 Initiating random data generation for index: 795
+2024/05/19 23:42:24 Generating 26043 numbers for index: 795
+2024/05/19 23:42:24 Initiating random data generation for index: 796
+2024/05/19 23:42:24 Generating 37681 numbers for index: 796
+2024/05/19 23:42:24 Initiating random data generation for index: 797
+2024/05/19 23:42:24 Generating 24801 numbers for index: 797
+2024/05/19 23:42:24 Initiating random data generation for index: 798
+2024/05/19 23:42:24 Generating 44898 numbers for index: 798
+2024/05/19 23:42:24 Initiating random data generation for index: 799
+2024/05/19 23:42:24 Initiating random data generation for index: 800
+2024/05/19 23:42:24 Initiating random data generation for index: 801
+2024/05/19 23:42:24 Generating 29521 numbers for index: 801
+2024/05/19 23:42:24 Initiating random data generation for index: 802
+2024/05/19 23:42:24 Generating 13671 numbers for index: 802
+2024/05/19 23:42:24 Initiating random data generation for index: 478
+2024/05/19 23:42:24 Generating 35509 numbers for index: 478
+2024/05/19 23:42:24 Initiating random data generation for index: 494
+2024/05/19 23:42:24 Generating 38034 numbers for index: 494
+2024/05/19 23:42:24 Generating 38684 numbers for index: 469
+2024/05/19 23:42:24 Initiating random data generation for index: 436
+2024/05/19 23:42:24 Generating 25183 numbers for index: 436
+2024/05/19 23:42:24 Initiating random data generation for index: 261
+2024/05/19 23:42:24 Generating 6521 numbers for index: 392
+2024/05/19 23:42:24 Initiating random data generation for index: 449
+2024/05/19 23:42:24 Initiating random data generation for index: 308
+2024/05/19 23:42:24 Initiating random data generation for index: 909
+2024/05/19 23:42:24 Initiating random data generation for index: 555
+2024/05/19 23:42:24 Initiating random data generation for index: 925
+2024/05/19 23:42:24 Initiating random data generation for index: 933
+2024/05/19 23:42:24 Initiating random data generation for index: 966
+2024/05/19 23:42:24 Initiating random data generation for index: 860
+2024/05/19 23:42:24 Initiating random data generation for index: 952
+2024/05/19 23:42:24 Initiating random data generation for index: 962
+2024/05/19 23:42:24 Initiating random data generation for index: 869
+2024/05/19 23:42:24 Initiating random data generation for index: 965
+2024/05/19 23:42:24 Initiating random data generation for index: 881
+2024/05/19 23:42:24 Initiating random data generation for index: 874
+2024/05/19 23:42:24 Initiating random data generation for index: 987
+2024/05/19 23:42:24 Initiating random data generation for index: 984
+2024/05/19 23:42:24 Generating 11498 numbers for index: 984
+2024/05/19 23:42:24 Initiating random data generation for index: 988
+2024/05/19 23:42:24 Generating 10324 numbers for index: 988
+2024/05/19 23:42:24 Initiating random data generation for index: 989
+2024/05/19 23:42:24 Initiating random data generation for index: 990
+2024/05/19 23:42:24 Generating 41829 numbers for index: 990
+2024/05/19 23:42:24 Initiating random data generation for index: 893
+2024/05/19 23:42:24 Generating 35822 numbers for index: 893
+2024/05/19 23:42:24 Initiating random data generation for index: 885
+2024/05/19 23:42:24 Initiating random data generation for index: 994
+2024/05/19 23:42:24 Generating 16628 numbers for index: 463
+2024/05/19 23:42:24 Generating 7161 numbers for index: 989
+2024/05/19 23:42:24 Generating 17043 numbers for index: 261
+2024/05/19 23:42:24 Initiating random data generation for index: 995
+2024/05/19 23:42:24 Generating 28838 numbers for index: 995
+2024/05/19 23:42:24 Initiating random data generation for index: 996
+2024/05/19 23:42:24 Initiating random data generation for index: 997
+2024/05/19 23:42:24 Generating 16823 numbers for index: 997
+2024/05/19 23:42:24 Initiating random data generation for index: 998
+2024/05/19 23:42:24 Initiating random data generation for index: 972
+2024/05/19 23:42:24 Generating 34132 numbers for index: 972
+2024/05/19 23:42:24 Initiating random data generation for index: 882
+2024/05/19 23:42:24 Generating 49979 numbers for index: 882
+2024/05/19 23:42:24 Generating 37087 numbers for index: 308
+2024/05/19 23:42:24 Initiating random data generation for index: 855
+2024/05/19 23:42:24 Generating 32829 numbers for index: 855
+2024/05/19 23:42:24 Generating 45504 numbers for index: 998
+2024/05/19 23:42:24 Generating 40003 numbers for index: 994
+2024/05/19 23:42:24 Generating 34707 numbers for index: 933
+2024/05/19 23:42:24 Initiating random data generation for index: 266
+2024/05/19 23:42:24 Generating 34147 numbers for index: 266
+2024/05/19 23:42:24 Generating 30564 numbers for index: 885
+2024/05/19 23:42:24 Generating 9425 numbers for index: 272
+2024/05/19 23:42:24 Initiating random data generation for index: 889
+2024/05/19 23:42:24 Generating 28576 numbers for index: 889
+2024/05/19 23:42:24 Generating 11035 numbers for index: 563
+2024/05/19 23:42:24 Generating 33003 numbers for index: 420
+2024/05/19 23:42:24 Initiating random data generation for index: 25
+2024/05/19 23:42:24 Generating 46056 numbers for index: 25
+2024/05/19 23:42:24 Initiating random data generation for index: 26
+2024/05/19 23:42:24 Generating 15558 numbers for index: 26
+2024/05/19 23:42:24 Initiating random data generation for index: 27
+2024/05/19 23:42:24 Initiating random data generation for index: 28
+2024/05/19 23:42:24 Initiating random data generation for index: 106
+2024/05/19 23:42:24 Initiating random data generation for index: 90
+2024/05/19 23:42:24 Initiating random data generation for index: 91
+2024/05/19 23:42:24 Initiating random data generation for index: 92
+2024/05/19 23:42:24 Initiating random data generation for index: 93
+2024/05/19 23:42:24 Generating 48637 numbers for index: 18
+2024/05/19 23:42:24 Initiating random data generation for index: 552
+2024/05/19 23:42:24 Initiating random data generation for index: 95
+2024/05/19 23:42:24 Initiating random data generation for index: 24
+2024/05/19 23:42:24 Initiating random data generation for index: 97
+2024/05/19 23:42:24 Initiating random data generation for index: 98
+2024/05/19 23:42:24 Initiating random data generation for index: 99
+2024/05/19 23:42:24 Generating 22584 numbers for index: 24
+2024/05/19 23:42:24 Generating 9926 numbers for index: 98
+2024/05/19 23:42:24 Initiating random data generation for index: 101
+2024/05/19 23:42:24 Initiating random data generation for index: 80
+2024/05/19 23:42:24 Generating 15623 numbers for index: 101
+2024/05/19 23:42:24 Initiating random data generation for index: 81
+2024/05/19 23:42:24 Initiating random data generation for index: 85
+2024/05/19 23:42:24 Generating 46734 numbers for index: 85
+2024/05/19 23:42:24 Generating 39814 numbers for index: 80
+2024/05/19 23:42:24 Initiating random data generation for index: 86
+2024/05/19 23:42:24 Initiating random data generation for index: 87
+2024/05/19 23:42:24 Initiating random data generation for index: 103
+2024/05/19 23:42:24 Initiating random data generation for index: 88
+2024/05/19 23:42:24 Generating 13286 numbers for index: 88
+2024/05/19 23:42:24 Initiating random data generation for index: 104
+2024/05/19 23:42:24 Generating 39070 numbers for index: 104
+2024/05/19 23:42:24 Initiating random data generation for index: 118
+2024/05/19 23:42:24 Initiating random data generation for index: 107
+2024/05/19 23:42:24 Generating 22435 numbers for index: 107
+2024/05/19 23:42:24 Initiating random data generation for index: 108
+2024/05/19 23:42:24 Initiating random data generation for index: 84
+2024/05/19 23:42:24 Initiating random data generation for index: 109
+2024/05/19 23:42:24 Initiating random data generation for index: 125
+2024/05/19 23:42:24 Initiating random data generation for index: 110
+2024/05/19 23:42:24 Generating 43328 numbers for index: 110
+2024/05/19 23:42:24 Generating 4030 numbers for index: 105
+2024/05/19 23:42:24 Initiating random data generation for index: 119
+2024/05/19 23:42:24 Initiating random data generation for index: 111
+2024/05/19 23:42:24 Initiating random data generation for index: 120
+2024/05/19 23:42:24 Generating 32000 numbers for index: 120
+2024/05/19 23:42:24 Initiating random data generation for index: 121
+2024/05/19 23:42:24 Initiating random data generation for index: 112
+2024/05/19 23:42:24 Generating 12601 numbers for index: 112
+2024/05/19 23:42:24 Initiating random data generation for index: 122
+2024/05/19 23:42:24 Initiating random data generation for index: 113
+2024/05/19 23:42:24 Generating 26054 numbers for index: 113
+2024/05/19 23:42:24 Initiating random data generation for index: 123
+2024/05/19 23:42:24 Generating 21603 numbers for index: 123
+2024/05/19 23:42:24 Generating 35338 numbers for index: 83
+2024/05/19 23:42:24 Initiating random data generation for index: 115
+2024/05/19 23:42:24 Generating 18187 numbers for index: 115
+2024/05/19 23:42:24 Initiating random data generation for index: 116
+2024/05/19 23:42:24 Initiating random data generation for index: 126
+2024/05/19 23:42:24 Generating 32994 numbers for index: 126
+2024/05/19 23:42:24 Initiating random data generation for index: 127
+2024/05/19 23:42:24 Initiating random data generation for index: 117
+2024/05/19 23:42:24 Generating 43900 numbers for index: 117
+2024/05/19 23:42:24 Initiating random data generation for index: 129
+2024/05/19 23:42:24 Generating 43323 numbers for index: 129
+2024/05/19 23:42:24 Initiating random data generation for index: 133
+2024/05/19 23:42:24 Initiating random data generation for index: 131
+2024/05/19 23:42:24 Generating 28515 numbers for index: 131
+2024/05/19 23:42:24 Generating 8695 numbers for index: 128
+2024/05/19 23:42:24 Initiating random data generation for index: 132
+2024/05/19 23:42:24 Generating 43727 numbers for index: 135
+2024/05/19 23:42:24 Initiating random data generation for index: 134
+2024/05/19 23:42:24 Generating 21888 numbers for index: 134
+2024/05/19 23:42:24 Initiating random data generation for index: 136
+2024/05/19 23:42:24 Generating 45068 numbers for index: 136
+2024/05/19 23:42:24 Generating 47839 numbers for index: 137
+2024/05/19 23:42:24 Initiating random data generation for index: 139
+2024/05/19 23:42:24 Generating 35451 numbers for index: 139
+2024/05/19 23:42:24 Generating 10209 numbers for index: 138
+2024/05/19 23:42:24 Initiating random data generation for index: 141
+2024/05/19 23:42:24 Initiating random data generation for index: 142
+2024/05/19 23:42:24 Generating 32823 numbers for index: 142
+2024/05/19 23:42:24 Initiating random data generation for index: 144
+2024/05/19 23:42:24 Generating 19592 numbers for index: 144
+2024/05/19 23:42:24 Initiating random data generation for index: 145
+2024/05/19 23:42:24 Initiating random data generation for index: 148
+2024/05/19 23:42:24 Generating 43927 numbers for index: 143
+2024/05/19 23:42:24 Initiating random data generation for index: 13
+2024/05/19 23:42:24 Initiating random data generation for index: 147
+2024/05/19 23:42:24 Generating 38708 numbers for index: 146
+2024/05/19 23:42:24 Initiating random data generation for index: 150
+2024/05/19 23:42:24 Generating 17147 numbers for index: 147
+2024/05/19 23:42:24 Generating 47471 numbers for index: 150
+2024/05/19 23:42:24 Generating 1593 numbers for index: 153
+2024/05/19 23:42:24 Generating 40849 numbers for index: 154
+2024/05/19 23:42:24 Initiating random data generation for index: 161
+2024/05/19 23:42:24 Initiating random data generation for index: 160
+2024/05/19 23:42:24 Generating 3950 numbers for index: 14
+2024/05/19 23:42:24 Generating 43483 numbers for index: 15
+2024/05/19 23:42:24 Initiating random data generation for index: 162
+2024/05/19 23:42:24 Generating 16526 numbers for index: 99
+2024/05/19 23:42:24 Initiating random data generation for index: 163
+2024/05/19 23:42:24 Generating 16487 numbers for index: 45
+2024/05/19 23:42:24 Generating 5744 numbers for index: 5
+2024/05/19 23:42:24 Initiating random data generation for index: 165
+2024/05/19 23:42:24 Generating 25688 numbers for index: 46
+2024/05/19 23:42:24 Initiating random data generation for index: 166
+2024/05/19 23:42:24 Initiating random data generation for index: 167
+2024/05/19 23:42:24 Generating 49408 numbers for index: 48
+2024/05/19 23:42:24 Generating 31189 numbers for index: 50
+2024/05/19 23:42:24 Initiating random data generation for index: 51
+2024/05/19 23:42:24 Initiating random data generation for index: 168
+2024/05/19 23:42:24 Initiating random data generation for index: 169
+2024/05/19 23:42:24 Initiating random data generation for index: 172
+2024/05/19 23:42:24 Initiating random data generation for index: 171
+2024/05/19 23:42:24 Initiating random data generation for index: 173
+2024/05/19 23:42:24 Initiating random data generation for index: 174
+2024/05/19 23:42:24 Initiating random data generation for index: 175
+2024/05/19 23:42:24 Generating 19883 numbers for index: 53
+2024/05/19 23:42:24 Initiating random data generation for index: 176
+2024/05/19 23:42:24 Initiating random data generation for index: 177
+2024/05/19 23:42:24 Generating 37301 numbers for index: 54
+2024/05/19 23:42:24 Initiating random data generation for index: 179
+2024/05/19 23:42:24 Initiating random data generation for index: 178
+2024/05/19 23:42:24 Generating 22887 numbers for index: 55
+2024/05/19 23:42:24 Generating 33969 numbers for index: 56
+2024/05/19 23:42:24 Initiating random data generation for index: 60
+2024/05/19 23:42:24 Generating 18323 numbers for index: 59
+2024/05/19 23:42:24 Initiating random data generation for index: 181
+2024/05/19 23:42:24 Initiating random data generation for index: 183
+2024/05/19 23:42:24 Generating 46804 numbers for index: 182
+2024/05/19 23:42:24 Initiating random data generation for index: 186
+2024/05/19 23:42:24 Initiating random data generation for index: 187
+2024/05/19 23:42:24 Generating 35745 numbers for index: 57
+2024/05/19 23:42:24 Initiating random data generation for index: 184
+2024/05/19 23:42:24 Initiating random data generation for index: 188
+2024/05/19 23:42:24 Generating 40573 numbers for index: 185
+2024/05/19 23:42:24 Initiating random data generation for index: 191
+2024/05/19 23:42:24 Generating 20874 numbers for index: 70
+2024/05/19 23:42:24 Initiating random data generation for index: 72
+2024/05/19 23:42:24 Initiating random data generation for index: 202
+2024/05/19 23:42:24 Generating 8140 numbers for index: 12
+2024/05/19 23:42:24 Generating 19254 numbers for index: 32
+2024/05/19 23:42:24 Initiating random data generation for index: 158
+2024/05/19 23:42:24 Initiating random data generation for index: 195
+2024/05/19 23:42:24 Initiating random data generation for index: 159
+2024/05/19 23:42:24 Initiating random data generation for index: 197
+2024/05/19 23:42:24 Generating 47541 numbers for index: 47
+2024/05/19 23:42:24 Generating 40403 numbers for index: 4
+2024/05/19 23:42:24 Generating 48697 numbers for index: 189
+2024/05/19 23:42:24 Initiating random data generation for index: 190
+2024/05/19 23:42:24 Initiating random data generation for index: 164
+2024/05/19 23:42:24 Initiating random data generation for index: 193
+2024/05/19 23:42:24 Generating 38721 numbers for index: 36
+2024/05/19 23:42:24 Generating 26214 numbers for index: 37
+2024/05/19 23:42:24 Generating 21248 numbers for index: 38
+2024/05/19 23:42:24 Generating 17552 numbers for index: 39
+2024/05/19 23:42:24 Generating 46645 numbers for index: 102
+2024/05/19 23:42:24 Generating 24498 numbers for index: 40
+2024/05/19 23:42:24 Initiating random data generation for index: 198
+2024/05/19 23:42:24 Generating 31822 numbers for index: 61
+2024/05/19 23:42:24 Generating 15844 numbers for index: 69
+2024/05/19 23:42:24 Initiating random data generation for index: 199
+2024/05/19 23:42:24 Initiating random data generation for index: 155
+2024/05/19 23:42:24 Initiating random data generation for index: 156
+2024/05/19 23:42:24 Initiating random data generation for index: 192
+2024/05/19 23:42:24 Generating 38465 numbers for index: 34
+2024/05/19 23:42:24 Initiating random data generation for index: 73
+2024/05/19 23:42:24 Initiating random data generation for index: 234
+2024/05/19 23:42:24 Generating 17231 numbers for index: 221
+2024/05/19 23:42:24 Initiating random data generation for index: 235
+2024/05/19 23:42:24 Initiating random data generation for index: 236
+2024/05/19 23:42:24 Initiating random data generation for index: 237
+2024/05/19 23:42:24 Initiating random data generation for index: 201
+2024/05/19 23:42:24 Initiating random data generation for index: 238
+2024/05/19 23:42:24 Initiating random data generation for index: 239
+2024/05/19 23:42:24 Generating 4097 numbers for index: 256
+2024/05/19 23:42:24 Initiating random data generation for index: 222
+2024/05/19 23:42:24 Initiating random data generation for index: 223
+2024/05/19 23:42:24 Initiating random data generation for index: 224
+2024/05/19 23:42:24 Initiating random data generation for index: 225
+2024/05/19 23:42:24 Initiating random data generation for index: 227
+2024/05/19 23:42:24 Generating 7020 numbers for index: 240
+2024/05/19 23:42:24 Initiating random data generation for index: 75
+2024/05/19 23:42:24 Initiating random data generation for index: 228
+2024/05/19 23:42:24 Initiating random data generation for index: 241
+2024/05/19 23:42:24 Initiating random data generation for index: 229
+2024/05/19 23:42:24 Initiating random data generation for index: 242
+2024/05/19 23:42:24 Initiating random data generation for index: 230
+2024/05/19 23:42:24 Initiating random data generation for index: 243
+2024/05/19 23:42:24 Initiating random data generation for index: 231
+2024/05/19 23:42:24 Initiating random data generation for index: 206
+2024/05/19 23:42:24 Initiating random data generation for index: 244
+2024/05/19 23:42:24 Initiating random data generation for index: 232
+2024/05/19 23:42:24 Initiating random data generation for index: 207
+2024/05/19 23:42:24 Initiating random data generation for index: 245
+2024/05/19 23:42:24 Initiating random data generation for index: 208
+2024/05/19 23:42:24 Initiating random data generation for index: 246
+2024/05/19 23:42:24 Initiating random data generation for index: 247
+2024/05/19 23:42:24 Initiating random data generation for index: 213
+2024/05/19 23:42:24 Initiating random data generation for index: 248
+2024/05/19 23:42:24 Initiating random data generation for index: 214
+2024/05/19 23:42:24 Initiating random data generation for index: 249
+2024/05/19 23:42:24 Initiating random data generation for index: 215
+2024/05/19 23:42:24 Initiating random data generation for index: 250
+2024/05/19 23:42:24 Generating 37631 numbers for index: 209
+2024/05/19 23:42:24 Initiating random data generation for index: 251
+2024/05/19 23:42:24 Initiating random data generation for index: 210
+2024/05/19 23:42:24 Initiating random data generation for index: 252
+2024/05/19 23:42:24 Initiating random data generation for index: 211
+2024/05/19 23:42:24 Initiating random data generation for index: 253
+2024/05/19 23:42:24 Initiating random data generation for index: 254
+2024/05/19 23:42:24 Generating 34882 numbers for index: 196
+2024/05/19 23:42:24 Generating 13178 numbers for index: 216
+2024/05/19 23:42:24 Initiating random data generation for index: 217
+2024/05/19 23:42:24 Initiating random data generation for index: 218
+2024/05/19 23:42:24 Initiating random data generation for index: 219
+2024/05/19 23:42:24 Generating 28199 numbers for index: 212
+2024/05/19 23:42:24 Generating 15529 numbers for index: 22
+2024/05/19 23:42:24 Initiating random data generation for index: 17
+2024/05/19 23:42:24 Initiating random data generation for index: 279
+2024/05/19 23:42:24 Initiating random data generation for index: 258
+2024/05/19 23:42:24 Initiating random data generation for index: 280
+2024/05/19 23:42:24 Initiating random data generation for index: 259
+2024/05/19 23:42:24 Initiating random data generation for index: 281
+2024/05/19 23:42:24 Initiating random data generation for index: 282
+2024/05/19 23:42:24 Initiating random data generation for index: 260
+2024/05/19 23:42:24 Initiating random data generation for index: 283
+2024/05/19 23:42:24 Generating 13668 numbers for index: 268
+2024/05/19 23:42:24 Initiating random data generation for index: 262
+2024/05/19 23:42:24 Generating 29813 numbers for index: 257
+2024/05/19 23:42:24 Initiating random data generation for index: 263
+2024/05/19 23:42:24 Initiating random data generation for index: 269
+2024/05/19 23:42:24 Initiating random data generation for index: 264
+2024/05/19 23:42:24 Initiating random data generation for index: 270
+2024/05/19 23:42:24 Initiating random data generation for index: 265
+2024/05/19 23:42:24 Initiating random data generation for index: 271
+2024/05/19 23:42:24 Generating 919 numbers for index: 284
+2024/05/19 23:42:24 Initiating random data generation for index: 285
+2024/05/19 23:42:24 Initiating random data generation for index: 286
+2024/05/19 23:42:24 Initiating random data generation for index: 267
+2024/05/19 23:42:24 Initiating random data generation for index: 288
+2024/05/19 23:42:24 Generating 3665 numbers for index: 287
+2024/05/19 23:42:24 Initiating random data generation for index: 273
+2024/05/19 23:42:24 Initiating random data generation for index: 298
+2024/05/19 23:42:24 Initiating random data generation for index: 274
+2024/05/19 23:42:24 Initiating random data generation for index: 299
+2024/05/19 23:42:24 Initiating random data generation for index: 275
+2024/05/19 23:42:24 Initiating random data generation for index: 306
+2024/05/19 23:42:24 Initiating random data generation for index: 276
+2024/05/19 23:42:24 Initiating random data generation for index: 300
+2024/05/19 23:42:24 Initiating random data generation for index: 277
+2024/05/19 23:42:24 Initiating random data generation for index: 301
+2024/05/19 23:42:24 Initiating random data generation for index: 307
+2024/05/19 23:42:24 Initiating random data generation for index: 302
+2024/05/19 23:42:24 Generating 35824 numbers for index: 289
+2024/05/19 23:42:24 Initiating random data generation for index: 309
+2024/05/19 23:42:24 Initiating random data generation for index: 310
+2024/05/19 23:42:24 Initiating random data generation for index: 311
+2024/05/19 23:42:24 Initiating random data generation for index: 314
+2024/05/19 23:42:24 Initiating random data generation for index: 312
+2024/05/19 23:42:24 Initiating random data generation for index: 304
+2024/05/19 23:42:24 Initiating random data generation for index: 313
+2024/05/19 23:42:24 Initiating random data generation for index: 315
+2024/05/19 23:42:24 Initiating random data generation for index: 316
+2024/05/19 23:42:24 Initiating random data generation for index: 305
+2024/05/19 23:42:24 Initiating random data generation for index: 317
+2024/05/19 23:42:24 Initiating random data generation for index: 321
+2024/05/19 23:42:24 Generating 25848 numbers for index: 87
+2024/05/19 23:42:24 Initiating random data generation for index: 322
+2024/05/19 23:42:24 Generating 23553 numbers for index: 322
+2024/05/19 23:42:24 Initiating random data generation for index: 319
+2024/05/19 23:42:24 Generating 35364 numbers for index: 319
+2024/05/19 23:42:24 Generating 34046 numbers for index: 251
+2024/05/19 23:42:24 Generating 3051 numbers for index: 121
+2024/05/19 23:42:24 Generating 25500 numbers for index: 252
+2024/05/19 23:42:24 Generating 19865 numbers for index: 211
+2024/05/19 23:42:24 Generating 8470 numbers for index: 288
+2024/05/19 23:42:24 Generating 887 numbers for index: 799
+2024/05/19 23:42:24 Generating 28056 numbers for index: 253
+2024/05/19 23:42:24 Initiating random data generation for index: 323
+2024/05/19 23:42:24 Generating 20000 numbers for index: 306
+2024/05/19 23:42:24 Generating 38858 numbers for index: 217
+2024/05/19 23:42:24 Generating 20848 numbers for index: 270
+2024/05/19 23:42:24 Generating 37899 numbers for index: 219
+2024/05/19 23:42:24 Generating 11810 numbers for index: 263
+2024/05/19 23:42:24 Generating 47900 numbers for index: 301
+2024/05/19 23:42:24 Generating 47422 numbers for index: 307
+2024/05/19 23:42:24 Generating 20336 numbers for index: 148
+2024/05/19 23:42:24 Generating 46905 numbers for index: 265
+2024/05/19 23:42:24 Generating 6817 numbers for index: 302
+2024/05/19 23:42:24 Generating 20962 numbers for index: 269
+2024/05/19 23:42:24 Generating 45552 numbers for index: 162
+2024/05/19 23:42:24 Generating 22163 numbers for index: 313
+2024/05/19 23:42:24 Generating 45129 numbers for index: 17
+2024/05/19 23:42:24 Generating 16822 numbers for index: 323
+2024/05/19 23:42:24 Generating 20379 numbers for index: 298
+2024/05/19 23:42:24 Generating 26302 numbers for index: 304
+2024/05/19 23:42:24 Generating 24643 numbers for index: 276
+2024/05/19 23:42:24 Generating 10617 numbers for index: 279
+2024/05/19 23:42:24 Generating 33860 numbers for index: 285
+2024/05/19 23:42:24 Generating 40032 numbers for index: 317
+2024/05/19 23:42:24 Generating 6199 numbers for index: 13
+2024/05/19 23:42:24 Generating 15234 numbers for index: 312
+2024/05/19 23:42:24 Generating 47531 numbers for index: 925
+2024/05/19 23:42:24 Initiating random data generation for index: 292
+2024/05/19 23:42:24 Generating 41887 numbers for index: 292
+2024/05/19 23:42:24 Generating 764 numbers for index: 552
+2024/05/19 23:42:24 Initiating random data generation for index: 328
+2024/05/19 23:42:24 Generating 28178 numbers for index: 328
+2024/05/19 23:42:24 Initiating random data generation for index: 329
+2024/05/19 23:42:24 Generating 39243 numbers for index: 329
+2024/05/19 23:42:24 Initiating random data generation for index: 293
+2024/05/19 23:42:24 Generating 3204 numbers for index: 293
+2024/05/19 23:42:24 Initiating random data generation for index: 330
+2024/05/19 23:42:24 Generating 37255 numbers for index: 330
+2024/05/19 23:42:24 Initiating random data generation for index: 327
+2024/05/19 23:42:24 Generating 18664 numbers for index: 327
+2024/05/19 23:42:24 Initiating random data generation for index: 325
+2024/05/19 23:42:24 Generating 17285 numbers for index: 325
+2024/05/19 23:42:24 Generating 34513 numbers for index: 132
+2024/05/19 23:42:24 Initiating random data generation for index: 332
+2024/05/19 23:42:24 Generating 27288 numbers for index: 332
+2024/05/19 23:42:24 Initiating random data generation for index: 331
+2024/05/19 23:42:24 Generating 24655 numbers for index: 331
+2024/05/19 23:42:24 Initiating random data generation for index: 296
+2024/05/19 23:42:24 Initiating random data generation for index: 337
+2024/05/19 23:42:24 Generating 31752 numbers for index: 337
+2024/05/19 23:42:24 Initiating random data generation for index: 291
+2024/05/19 23:42:24 Initiating random data generation for index: 338
+2024/05/19 23:42:24 Initiating random data generation for index: 339
+2024/05/19 23:42:24 Initiating random data generation for index: 340
+2024/05/19 23:42:24 Generating 6687 numbers for index: 339
+2024/05/19 23:42:24 Generating 28035 numbers for index: 326
+2024/05/19 23:42:24 Initiating random data generation for index: 342
+2024/05/19 23:42:24 Generating 27474 numbers for index: 299
+2024/05/19 23:42:24 Generating 6329 numbers for index: 158
+2024/05/19 23:42:24 Initiating random data generation for index: 343
+2024/05/19 23:42:24 Initiating random data generation for index: 344
+2024/05/19 23:42:24 Initiating random data generation for index: 350
+2024/05/19 23:42:24 Initiating random data generation for index: 347
+2024/05/19 23:42:24 Initiating random data generation for index: 348
+2024/05/19 23:42:24 Initiating random data generation for index: 351
+2024/05/19 23:42:24 Initiating random data generation for index: 345
+2024/05/19 23:42:24 Initiating random data generation for index: 352
+2024/05/19 23:42:24 Initiating random data generation for index: 354
+2024/05/19 23:42:24 Initiating random data generation for index: 353
+2024/05/19 23:42:24 Generating 21884 numbers for index: 341
+2024/05/19 23:42:24 Initiating random data generation for index: 360
+2024/05/19 23:42:24 Initiating random data generation for index: 361
+2024/05/19 23:42:24 Initiating random data generation for index: 334
+2024/05/19 23:42:24 Initiating random data generation for index: 335
+2024/05/19 23:42:24 Initiating random data generation for index: 336
+2024/05/19 23:42:24 Generating 17498 numbers for index: 355
+2024/05/19 23:42:24 Generating 22265 numbers for index: 357
+2024/05/19 23:42:24 Initiating random data generation for index: 362
+2024/05/19 23:42:24 Initiating random data generation for index: 358
+2024/05/19 23:42:24 Generating 38833 numbers for index: 171
+2024/05/19 23:42:24 Initiating random data generation for index: 20
+2024/05/19 23:42:24 Generating 18898 numbers for index: 20
+2024/05/19 23:42:24 Initiating random data generation for index: 359
+2024/05/19 23:42:24 Generating 39866 numbers for index: 359
+2024/05/19 23:42:24 Generating 9562 numbers for index: 103
+2024/05/19 23:42:24 Generating 31247 numbers for index: 116
+2024/05/19 23:42:24 Generating 6222 numbers for index: 179
+2024/05/19 23:42:24 Generating 41119 numbers for index: 173
+2024/05/19 23:42:24 Generating 25773 numbers for index: 166
+2024/05/19 23:42:24 Generating 37838 numbers for index: 167
+2024/05/19 23:42:24 Generating 47849 numbers for index: 159
+2024/05/19 23:42:24 Generating 36349 numbers for index: 175
+2024/05/19 23:42:24 Generating 5 numbers for index: 190
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_190.txt for index: 190
+2024/05/19 23:42:24 Generating 25815 numbers for index: 75
+2024/05/19 23:42:24 Generating 24279 numbers for index: 164
+2024/05/19 23:42:24 Generating 42754 numbers for index: 197
+2024/05/19 23:42:24 Generating 33818 numbers for index: 213
+2024/05/19 23:42:24 Generating 13587 numbers for index: 214
+2024/05/19 23:42:24 Initiating random data generation for index: 346
+2024/05/19 23:42:24 Initiating random data generation for index: 366
+2024/05/19 23:42:24 Initiating random data generation for index: 369
+2024/05/19 23:42:24 Initiating random data generation for index: 365
+2024/05/19 23:42:24 Generating 39777 numbers for index: 365
+2024/05/19 23:42:24 Generating 9570 numbers for index: 174
+2024/05/19 23:42:24 Generating 6146 numbers for index: 181
+2024/05/19 23:42:24 Generating 4227 numbers for index: 165
+2024/05/19 23:42:24 Generating 816 numbers for index: 274
+2024/05/19 23:42:24 Generating 165 numbers for index: 177
+2024/05/19 23:42:24 Generating 755 numbers for index: 127
+2024/05/19 23:42:24 Generating 14564 numbers for index: 336
+2024/05/19 23:42:24 Generating 46429 numbers for index: 356
+2024/05/19 23:42:24 Initiating random data generation for index: 373
+2024/05/19 23:42:24 Generating 2752 numbers for index: 373
+2024/05/19 23:42:24 Generating 46691 numbers for index: 368
+2024/05/19 23:42:24 Generating 25381 numbers for index: 364
+2024/05/19 23:42:24 Generating 106 numbers for index: 324
+2024/05/19 23:42:24 Initiating random data generation for index: 376
+2024/05/19 23:42:24 Generating 41097 numbers for index: 376
+2024/05/19 23:42:24 Initiating random data generation for index: 372
+2024/05/19 23:42:24 Generating 44080 numbers for index: 372
+2024/05/19 23:42:24 Initiating random data generation for index: 374
+2024/05/19 23:42:24 Generating 29273 numbers for index: 374
+2024/05/19 23:42:24 Initiating random data generation for index: 379
+2024/05/19 23:42:24 Generating 36295 numbers for index: 379
+2024/05/19 23:42:24 Initiating random data generation for index: 380
+2024/05/19 23:42:24 Generating 29049 numbers for index: 380
+2024/05/19 23:42:24 Generating 27398 numbers for index: 377
+2024/05/19 23:42:24 Initiating random data generation for index: 382
+2024/05/19 23:42:24 Initiating random data generation for index: 383
+2024/05/19 23:42:24 Initiating random data generation for index: 384
+2024/05/19 23:42:24 Generating 4768 numbers for index: 383
+2024/05/19 23:42:24 Generating 7621 numbers for index: 384
+2024/05/19 23:42:24 Generating 13932 numbers for index: 370
+2024/05/19 23:42:24 Initiating random data generation for index: 471
+2024/05/19 23:42:24 Generating 24559 numbers for index: 471
+2024/05/19 23:42:24 Generating 22373 numbers for index: 309
+2024/05/19 23:42:24 Initiating random data generation for index: 386
+2024/05/19 23:42:24 Generating 43175 numbers for index: 386
+2024/05/19 23:42:24 Initiating random data generation for index: 387
+2024/05/19 23:42:24 Generating 22750 numbers for index: 387
+2024/05/19 23:42:24 Initiating random data generation for index: 385
+2024/05/19 23:42:24 Generating 47522 numbers for index: 385
+2024/05/19 23:42:24 Initiating random data generation for index: 388
+2024/05/19 23:42:24 Generating 4932 numbers for index: 388
+2024/05/19 23:42:24 Initiating random data generation for index: 390
+2024/05/19 23:42:24 Generating 35277 numbers for index: 390
+2024/05/19 23:42:24 Initiating random data generation for index: 437
+2024/05/19 23:42:24 Generating 1498 numbers for index: 437
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_799.txt for index: 799
+2024/05/19 23:42:24 Initiating random data generation for index: 438
+2024/05/19 23:42:24 Initiating random data generation for index: 439
+2024/05/19 23:42:24 Initiating random data generation for index: 440
+2024/05/19 23:42:24 Initiating random data generation for index: 442
+2024/05/19 23:42:24 Initiating random data generation for index: 400
+2024/05/19 23:42:24 Initiating random data generation for index: 450
+2024/05/19 23:42:24 Initiating random data generation for index: 451
+2024/05/19 23:42:24 Initiating random data generation for index: 452
+2024/05/19 23:42:24 Initiating random data generation for index: 453
+2024/05/19 23:42:24 Initiating random data generation for index: 454
+2024/05/19 23:42:24 Initiating random data generation for index: 455
+2024/05/19 23:42:24 Initiating random data generation for index: 456
+2024/05/19 23:42:24 Initiating random data generation for index: 457
+2024/05/19 23:42:24 Initiating random data generation for index: 458
+2024/05/19 23:42:24 Initiating random data generation for index: 459
+2024/05/19 23:42:24 Initiating random data generation for index: 460
+2024/05/19 23:42:24 Initiating random data generation for index: 461
+2024/05/19 23:42:24 Initiating random data generation for index: 462
+2024/05/19 23:42:24 Generating 28286 numbers for index: 349
+2024/05/19 23:42:24 Initiating random data generation for index: 402
+2024/05/19 23:42:24 Generating 26402 numbers for index: 402
+2024/05/19 23:42:24 Initiating random data generation for index: 403
+2024/05/19 23:42:24 Generating 33675 numbers for index: 403
+2024/05/19 23:42:24 Initiating random data generation for index: 404
+2024/05/19 23:42:24 Initiating random data generation for index: 405
+2024/05/19 23:42:24 Generating 15571 numbers for index: 564
+2024/05/19 23:42:24 Initiating random data generation for index: 406
+2024/05/19 23:42:24 Initiating random data generation for index: 407
+2024/05/19 23:42:24 Initiating random data generation for index: 408
+2024/05/19 23:42:24 Initiating random data generation for index: 464
+2024/05/19 23:42:24 Initiating random data generation for index: 465
+2024/05/19 23:42:24 Initiating random data generation for index: 466
+2024/05/19 23:42:24 Initiating random data generation for index: 467
+2024/05/19 23:42:24 Initiating random data generation for index: 468
+2024/05/19 23:42:24 Initiating random data generation for index: 389
+2024/05/19 23:42:24 Initiating random data generation for index: 410
+2024/05/19 23:42:24 Initiating random data generation for index: 411
+2024/05/19 23:42:24 Initiating random data generation for index: 470
+2024/05/19 23:42:24 Initiating random data generation for index: 472
+2024/05/19 23:42:24 Initiating random data generation for index: 413
+2024/05/19 23:42:24 Initiating random data generation for index: 414
+2024/05/19 23:42:24 Initiating random data generation for index: 415
+2024/05/19 23:42:24 Generating 33637 numbers for index: 473
+2024/05/19 23:42:24 Initiating random data generation for index: 474
+2024/05/19 23:42:24 Initiating random data generation for index: 475
+2024/05/19 23:42:24 Initiating random data generation for index: 476
+2024/05/19 23:42:24 Initiating random data generation for index: 477
+2024/05/19 23:42:24 Initiating random data generation for index: 479
+2024/05/19 23:42:24 Initiating random data generation for index: 480
+2024/05/19 23:42:24 Initiating random data generation for index: 504
+2024/05/19 23:42:24 Initiating random data generation for index: 505
+2024/05/19 23:42:24 Initiating random data generation for index: 506
+2024/05/19 23:42:24 Initiating random data generation for index: 507
+2024/05/19 23:42:24 Initiating random data generation for index: 508
+2024/05/19 23:42:24 Initiating random data generation for index: 509
+2024/05/19 23:42:24 Initiating random data generation for index: 549
+2024/05/19 23:42:24 Initiating random data generation for index: 526
+2024/05/19 23:42:24 Initiating random data generation for index: 527
+2024/05/19 23:42:24 Initiating random data generation for index: 528
+2024/05/19 23:42:24 Initiating random data generation for index: 529
+2024/05/19 23:42:24 Initiating random data generation for index: 531
+2024/05/19 23:42:24 Initiating random data generation for index: 532
+2024/05/19 23:42:24 Initiating random data generation for index: 533
+2024/05/19 23:42:24 Generating 46302 numbers for index: 524
+2024/05/19 23:42:24 Initiating random data generation for index: 534
+2024/05/19 23:42:24 Initiating random data generation for index: 417
+2024/05/19 23:42:24 Initiating random data generation for index: 514
+2024/05/19 23:42:24 Initiating random data generation for index: 535
+2024/05/19 23:42:24 Initiating random data generation for index: 418
+2024/05/19 23:42:24 Generating 1070 numbers for index: 418
+2024/05/19 23:42:24 Initiating random data generation for index: 536
+2024/05/19 23:42:24 Initiating random data generation for index: 515
+2024/05/19 23:42:24 Initiating random data generation for index: 419
+2024/05/19 23:42:24 Initiating random data generation for index: 537
+2024/05/19 23:42:24 Initiating random data generation for index: 516
+2024/05/19 23:42:24 Initiating random data generation for index: 517
+2024/05/19 23:42:24 Initiating random data generation for index: 518
+2024/05/19 23:42:24 Initiating random data generation for index: 519
+2024/05/19 23:42:24 Initiating random data generation for index: 520
+2024/05/19 23:42:24 Initiating random data generation for index: 521
+2024/05/19 23:42:24 Initiating random data generation for index: 522
+2024/05/19 23:42:24 Initiating random data generation for index: 421
+2024/05/19 23:42:24 Initiating random data generation for index: 422
+2024/05/19 23:42:24 Generating 36126 numbers for index: 533
+2024/05/19 23:42:24 Initiating random data generation for index: 423
+2024/05/19 23:42:24 Initiating random data generation for index: 424
+2024/05/19 23:42:24 Generating 10555 numbers for index: 538
+2024/05/19 23:42:24 Initiating random data generation for index: 539
+2024/05/19 23:42:24 Initiating random data generation for index: 425
+2024/05/19 23:42:24 Initiating random data generation for index: 540
+2024/05/19 23:42:24 Initiating random data generation for index: 426
+2024/05/19 23:42:24 Initiating random data generation for index: 541
+2024/05/19 23:42:24 Initiating random data generation for index: 542
+2024/05/19 23:42:24 Initiating random data generation for index: 427
+2024/05/19 23:42:24 Initiating random data generation for index: 428
+2024/05/19 23:42:24 Initiating random data generation for index: 429
+2024/05/19 23:42:24 Generating 29427 numbers for index: 523
+2024/05/19 23:42:24 Initiating random data generation for index: 430
+2024/05/19 23:42:24 Initiating random data generation for index: 431
+2024/05/19 23:42:24 Initiating random data generation for index: 432
+2024/05/19 23:42:24 Generating 18215 numbers for index: 447
+2024/05/19 23:42:24 Initiating random data generation for index: 433
+2024/05/19 23:42:24 Initiating random data generation for index: 544
+2024/05/19 23:42:24 Initiating random data generation for index: 545
+2024/05/19 23:42:24 Initiating random data generation for index: 546
+2024/05/19 23:42:24 Initiating random data generation for index: 547
+2024/05/19 23:42:24 Initiating random data generation for index: 548
+2024/05/19 23:42:24 Initiating random data generation for index: 487
+2024/05/19 23:42:24 Initiating random data generation for index: 489
+2024/05/19 23:42:24 Initiating random data generation for index: 562
+2024/05/19 23:42:24 Initiating random data generation for index: 490
+2024/05/19 23:42:24 Initiating random data generation for index: 550
+2024/05/19 23:42:24 Initiating random data generation for index: 491
+2024/05/19 23:42:24 Initiating random data generation for index: 492
+2024/05/19 23:42:24 Initiating random data generation for index: 551
+2024/05/19 23:42:24 Initiating random data generation for index: 553
+2024/05/19 23:42:24 Initiating random data generation for index: 554
+2024/05/19 23:42:24 Initiating random data generation for index: 556
+2024/05/19 23:42:24 Initiating random data generation for index: 557
+2024/05/19 23:42:24 Generating 16872 numbers for index: 488
+2024/05/19 23:42:24 Initiating random data generation for index: 495
+2024/05/19 23:42:24 Initiating random data generation for index: 496
+2024/05/19 23:42:24 Initiating random data generation for index: 497
+2024/05/19 23:42:24 Initiating random data generation for index: 498
+2024/05/19 23:42:24 Initiating random data generation for index: 499
+2024/05/19 23:42:24 Initiating random data generation for index: 500
+2024/05/19 23:42:24 Initiating random data generation for index: 501
+2024/05/19 23:42:24 Generating 3023 numbers for index: 559
+2024/05/19 23:42:24 Initiating random data generation for index: 560
+2024/05/19 23:42:24 Initiating random data generation for index: 561
+2024/05/19 23:42:24 Generating 6418 numbers for index: 396
+2024/05/19 23:42:24 Initiating random data generation for index: 565
+2024/05/19 23:42:24 Initiating random data generation for index: 566
+2024/05/19 23:42:24 Initiating random data generation for index: 567
+2024/05/19 23:42:24 Initiating random data generation for index: 568
+2024/05/19 23:42:24 Initiating random data generation for index: 569
+2024/05/19 23:42:24 Initiating random data generation for index: 570
+2024/05/19 23:42:24 Initiating random data generation for index: 571
+2024/05/19 23:42:24 Initiating random data generation for index: 572
+2024/05/19 23:42:24 Initiating random data generation for index: 573
+2024/05/19 23:42:24 Initiating random data generation for index: 574
+2024/05/19 23:42:24 Initiating random data generation for index: 575
+2024/05/19 23:42:24 Initiating random data generation for index: 576
+2024/05/19 23:42:24 Initiating random data generation for index: 577
+2024/05/19 23:42:24 Initiating random data generation for index: 578
+2024/05/19 23:42:24 Initiating random data generation for index: 579
+2024/05/19 23:42:24 Initiating random data generation for index: 580
+2024/05/19 23:42:24 Initiating random data generation for index: 581
+2024/05/19 23:42:24 Initiating random data generation for index: 582
+2024/05/19 23:42:24 Initiating random data generation for index: 583
+2024/05/19 23:42:24 Initiating random data generation for index: 584
+2024/05/19 23:42:24 Initiating random data generation for index: 585
+2024/05/19 23:42:24 Initiating random data generation for index: 586
+2024/05/19 23:42:24 Initiating random data generation for index: 587
+2024/05/19 23:42:24 Initiating random data generation for index: 588
+2024/05/19 23:42:24 Initiating random data generation for index: 589
+2024/05/19 23:42:24 Initiating random data generation for index: 590
+2024/05/19 23:42:24 Initiating random data generation for index: 591
+2024/05/19 23:42:24 Initiating random data generation for index: 592
+2024/05/19 23:42:24 Initiating random data generation for index: 593
+2024/05/19 23:42:24 Initiating random data generation for index: 594
+2024/05/19 23:42:24 Generating 14253 numbers for index: 568
+2024/05/19 23:42:24 Generating 18136 numbers for index: 456
+2024/05/19 23:42:24 Generating 1938 numbers for index: 475
+2024/05/19 23:42:24 Generating 33603 numbers for index: 414
+2024/05/19 23:42:24 Generating 31773 numbers for index: 527
+2024/05/19 23:42:24 Generating 11413 numbers for index: 429
+2024/05/19 23:42:24 Generating 35846 numbers for index: 389
+2024/05/19 23:42:24 Generating 40057 numbers for index: 408
+2024/05/19 23:42:24 Generating 39986 numbers for index: 468
+2024/05/19 23:42:24 Generating 27757 numbers for index: 569
+2024/05/19 23:42:24 Generating 26628 numbers for index: 579
+2024/05/19 23:42:24 Generating 7564 numbers for index: 479
+2024/05/19 23:42:24 Generating 33680 numbers for index: 532
+2024/05/19 23:42:24 Generating 22328 numbers for index: 550
+2024/05/19 23:42:24 Generating 48966 numbers for index: 585
+2024/05/19 23:42:24 Generating 48687 numbers for index: 406
+2024/05/19 23:42:24 Generating 6102 numbers for index: 529
+2024/05/19 23:42:24 Generating 1337 numbers for index: 582
+2024/05/19 23:42:24 Generating 37482 numbers for index: 549
+2024/05/19 23:42:24 Generating 3238 numbers for index: 474
+2024/05/19 23:42:24 Generating 16851 numbers for index: 572
+2024/05/19 23:42:24 Generating 12297 numbers for index: 427
+2024/05/19 23:42:24 Generating 35704 numbers for index: 432
+2024/05/19 23:42:24 Generating 41751 numbers for index: 405
+2024/05/19 23:42:24 Generating 44549 numbers for index: 586
+2024/05/19 23:42:24 Generating 21567 numbers for index: 589
+2024/05/19 23:42:24 Generating 4900 numbers for index: 566
+2024/05/19 23:42:24 Generating 45689 numbers for index: 571
+2024/05/19 23:42:24 Generating 37622 numbers for index: 454
+2024/05/19 23:42:24 Generating 16566 numbers for index: 464
+2024/05/19 23:42:24 Generating 6466 numbers for index: 531
+2024/05/19 23:42:24 Generating 99 numbers for index: 506
+2024/05/19 23:42:24 Initiating random data generation for index: 598
+2024/05/19 23:42:24 Generating 969 numbers for index: 598
+2024/05/19 23:42:24 Generating 31664 numbers for index: 477
+2024/05/19 23:42:24 Generating 3689 numbers for index: 491
+2024/05/19 23:42:24 Generating 31560 numbers for index: 470
+2024/05/19 23:42:24 Generating 26295 numbers for index: 577
+2024/05/19 23:42:24 Generating 6075 numbers for index: 442
+2024/05/19 23:42:24 Initiating random data generation for index: 600
+2024/05/19 23:42:24 Initiating random data generation for index: 601
+2024/05/19 23:42:24 Initiating random data generation for index: 602
+2024/05/19 23:42:24 Initiating random data generation for index: 603
+2024/05/19 23:42:24 Initiating random data generation for index: 604
+2024/05/19 23:42:24 Initiating random data generation for index: 605
+2024/05/19 23:42:24 Initiating random data generation for index: 606
+2024/05/19 23:42:24 Initiating random data generation for index: 607
+2024/05/19 23:42:24 Initiating random data generation for index: 608
+2024/05/19 23:42:24 Initiating random data generation for index: 609
+2024/05/19 23:42:24 Initiating random data generation for index: 610
+2024/05/19 23:42:24 Generating 14002 numbers for index: 575
+2024/05/19 23:42:24 Generating 22678 numbers for index: 492
+2024/05/19 23:42:24 Generating 45084 numbers for index: 400
+2024/05/19 23:42:24 Generating 33404 numbers for index: 509
+2024/05/19 23:42:24 Generating 19862 numbers for index: 450
+2024/05/19 23:42:24 Generating 7488 numbers for index: 455
+2024/05/19 23:42:24 Generating 569 numbers for index: 601
+2024/05/19 23:42:24 Generating 42190 numbers for index: 603
+2024/05/19 23:42:24 Initiating random data generation for index: 599
+2024/05/19 23:42:24 Generating 46690 numbers for index: 599
+2024/05/19 23:42:24 Generating 38424 numbers for index: 604
+2024/05/19 23:42:24 Generating 40193 numbers for index: 526
+2024/05/19 23:42:24 Generating 23432 numbers for index: 609
+2024/05/19 23:42:24 Generating 38874 numbers for index: 607
+2024/05/19 23:42:24 Generating 48025 numbers for index: 505
+2024/05/19 23:42:24 Generating 5826 numbers for index: 551
+2024/05/19 23:42:24 Generating 8112 numbers for index: 440
+2024/05/19 23:42:24 Generating 21868 numbers for index: 590
+2024/05/19 23:42:24 Initiating random data generation for index: 612
+2024/05/19 23:42:24 Generating 90 numbers for index: 612
+2024/05/19 23:42:24 Initiating random data generation for index: 613
+2024/05/19 23:42:24 Generating 49144 numbers for index: 613
+2024/05/19 23:42:24 Generating 47057 numbers for index: 452
+2024/05/19 23:42:24 Generating 20249 numbers for index: 544
+2024/05/19 23:42:24 Generating 8657 numbers for index: 602
+2024/05/19 23:42:24 Generating 47781 numbers for index: 546
+2024/05/19 23:42:24 Generating 15080 numbers for index: 553
+2024/05/19 23:42:24 Generating 16560 numbers for index: 507
+2024/05/19 23:42:24 Generating 22966 numbers for index: 545
+2024/05/19 23:42:24 Generating 16398 numbers for index: 600
+2024/05/19 23:42:24 Generating 8641 numbers for index: 453
+2024/05/19 23:42:24 Initiating random data generation for index: 611
+2024/05/19 23:42:24 Generating 34634 numbers for index: 606
+2024/05/19 23:42:24 Generating 29138 numbers for index: 451
+2024/05/19 23:42:24 Generating 41947 numbers for index: 556
+2024/05/19 23:42:24 Generating 32732 numbers for index: 610
+2024/05/19 23:42:24 Generating 20900 numbers for index: 541
+2024/05/19 23:42:24 Initiating random data generation for index: 614
+2024/05/19 23:42:24 Generating 1790 numbers for index: 614
+2024/05/19 23:42:24 Generating 31705 numbers for index: 495
+2024/05/19 23:42:24 Initiating random data generation for index: 616
+2024/05/19 23:42:24 Initiating random data generation for index: 617
+2024/05/19 23:42:24 Generating 2066 numbers for index: 617
+2024/05/19 23:42:24 Generating 44555 numbers for index: 496
+2024/05/19 23:42:24 Initiating random data generation for index: 615
+2024/05/19 23:42:24 Initiating random data generation for index: 621
+2024/05/19 23:42:24 Initiating random data generation for index: 622
+2024/05/19 23:42:24 Initiating random data generation for index: 623
+2024/05/19 23:42:24 Initiating random data generation for index: 624
+2024/05/19 23:42:24 Initiating random data generation for index: 625
+2024/05/19 23:42:24 Initiating random data generation for index: 626
+2024/05/19 23:42:24 Initiating random data generation for index: 627
+2024/05/19 23:42:24 Initiating random data generation for index: 628
+2024/05/19 23:42:24 Initiating random data generation for index: 629
+2024/05/19 23:42:24 Initiating random data generation for index: 630
+2024/05/19 23:42:24 Initiating random data generation for index: 631
+2024/05/19 23:42:24 Initiating random data generation for index: 632
+2024/05/19 23:42:24 Initiating random data generation for index: 633
+2024/05/19 23:42:24 Initiating random data generation for index: 634
+2024/05/19 23:42:24 Initiating random data generation for index: 635
+2024/05/19 23:42:24 Initiating random data generation for index: 636
+2024/05/19 23:42:24 Initiating random data generation for index: 637
+2024/05/19 23:42:24 Initiating random data generation for index: 638
+2024/05/19 23:42:24 Initiating random data generation for index: 639
+2024/05/19 23:42:24 Initiating random data generation for index: 640
+2024/05/19 23:42:24 Initiating random data generation for index: 641
+2024/05/19 23:42:24 Initiating random data generation for index: 642
+2024/05/19 23:42:24 Initiating random data generation for index: 643
+2024/05/19 23:42:24 Initiating random data generation for index: 644
+2024/05/19 23:42:24 Initiating random data generation for index: 645
+2024/05/19 23:42:24 Initiating random data generation for index: 646
+2024/05/19 23:42:24 Initiating random data generation for index: 647
+2024/05/19 23:42:24 Initiating random data generation for index: 650
+2024/05/19 23:42:24 Initiating random data generation for index: 648
+2024/05/19 23:42:24 Initiating random data generation for index: 649
+2024/05/19 23:42:24 Initiating random data generation for index: 651
+2024/05/19 23:42:24 Initiating random data generation for index: 652
+2024/05/19 23:42:24 Initiating random data generation for index: 653
+2024/05/19 23:42:24 Initiating random data generation for index: 654
+2024/05/19 23:42:24 Initiating random data generation for index: 655
+2024/05/19 23:42:24 Initiating random data generation for index: 656
+2024/05/19 23:42:24 Initiating random data generation for index: 659
+2024/05/19 23:42:24 Initiating random data generation for index: 660
+2024/05/19 23:42:24 Initiating random data generation for index: 657
+2024/05/19 23:42:24 Initiating random data generation for index: 661
+2024/05/19 23:42:24 Initiating random data generation for index: 658
+2024/05/19 23:42:24 Initiating random data generation for index: 662
+2024/05/19 23:42:24 Initiating random data generation for index: 665
+2024/05/19 23:42:24 Initiating random data generation for index: 663
+2024/05/19 23:42:24 Initiating random data generation for index: 666
+2024/05/19 23:42:24 Initiating random data generation for index: 667
+2024/05/19 23:42:24 Initiating random data generation for index: 664
+2024/05/19 23:42:24 Initiating random data generation for index: 668
+2024/05/19 23:42:24 Initiating random data generation for index: 669
+2024/05/19 23:42:24 Initiating random data generation for index: 671
+2024/05/19 23:42:24 Generating 49716 numbers for index: 417
+2024/05/19 23:42:24 Generating 8131 numbers for index: 514
+2024/05/19 23:42:24 Generating 20507 numbers for index: 535
+2024/05/19 23:42:24 Initiating random data generation for index: 670
+2024/05/19 23:42:24 Generating 4418 numbers for index: 670
+2024/05/19 23:42:24 Initiating random data generation for index: 673
+2024/05/19 23:42:24 Initiating random data generation for index: 675
+2024/05/19 23:42:24 Generating 27420 numbers for index: 675
+2024/05/19 23:42:24 Generating 46750 numbers for index: 497
+2024/05/19 23:42:24 Initiating random data generation for index: 674
+2024/05/19 23:42:24 Initiating random data generation for index: 676
+2024/05/19 23:42:24 Initiating random data generation for index: 677
+2024/05/19 23:42:24 Initiating random data generation for index: 679
+2024/05/19 23:42:24 Initiating random data generation for index: 678
+2024/05/19 23:42:24 Initiating random data generation for index: 681
+2024/05/19 23:42:24 Initiating random data generation for index: 680
+2024/05/19 23:42:24 Initiating random data generation for index: 682
+2024/05/19 23:42:24 Initiating random data generation for index: 683
+2024/05/19 23:42:24 Initiating random data generation for index: 684
+2024/05/19 23:42:24 Initiating random data generation for index: 685
+2024/05/19 23:42:24 Initiating random data generation for index: 686
+2024/05/19 23:42:24 Initiating random data generation for index: 687
+2024/05/19 23:42:24 Initiating random data generation for index: 688
+2024/05/19 23:42:24 Initiating random data generation for index: 689
+2024/05/19 23:42:24 Initiating random data generation for index: 690
+2024/05/19 23:42:24 Initiating random data generation for index: 691
+2024/05/19 23:42:24 Initiating random data generation for index: 692
+2024/05/19 23:42:24 Initiating random data generation for index: 821
+2024/05/19 23:42:24 Initiating random data generation for index: 778
+2024/05/19 23:42:24 Initiating random data generation for index: 693
+2024/05/19 23:42:24 Initiating random data generation for index: 694
+2024/05/19 23:42:24 Initiating random data generation for index: 695
+2024/05/19 23:42:24 Initiating random data generation for index: 696
+2024/05/19 23:42:24 Initiating random data generation for index: 697
+2024/05/19 23:42:24 Initiating random data generation for index: 698
+2024/05/19 23:42:24 Initiating random data generation for index: 699
+2024/05/19 23:42:24 Initiating random data generation for index: 700
+2024/05/19 23:42:24 Initiating random data generation for index: 701
+2024/05/19 23:42:24 Initiating random data generation for index: 702
+2024/05/19 23:42:24 Initiating random data generation for index: 703
+2024/05/19 23:42:24 Initiating random data generation for index: 704
+2024/05/19 23:42:24 Initiating random data generation for index: 705
+2024/05/19 23:42:24 Initiating random data generation for index: 706
+2024/05/19 23:42:24 Initiating random data generation for index: 707
+2024/05/19 23:42:24 Initiating random data generation for index: 708
+2024/05/19 23:42:24 Initiating random data generation for index: 709
+2024/05/19 23:42:24 Initiating random data generation for index: 710
+2024/05/19 23:42:24 Initiating random data generation for index: 711
+2024/05/19 23:42:24 Initiating random data generation for index: 712
+2024/05/19 23:42:24 Initiating random data generation for index: 713
+2024/05/19 23:42:24 Initiating random data generation for index: 714
+2024/05/19 23:42:24 Initiating random data generation for index: 715
+2024/05/19 23:42:24 Initiating random data generation for index: 716
+2024/05/19 23:42:24 Initiating random data generation for index: 717
+2024/05/19 23:42:24 Initiating random data generation for index: 718
+2024/05/19 23:42:24 Initiating random data generation for index: 719
+2024/05/19 23:42:24 Initiating random data generation for index: 720
+2024/05/19 23:42:24 Initiating random data generation for index: 721
+2024/05/19 23:42:24 Initiating random data generation for index: 722
+2024/05/19 23:42:24 Initiating random data generation for index: 723
+2024/05/19 23:42:24 Initiating random data generation for index: 724
+2024/05/19 23:42:24 Initiating random data generation for index: 725
+2024/05/19 23:42:24 Initiating random data generation for index: 726
+2024/05/19 23:42:24 Initiating random data generation for index: 727
+2024/05/19 23:42:24 Initiating random data generation for index: 728
+2024/05/19 23:42:24 Initiating random data generation for index: 729
+2024/05/19 23:42:24 Initiating random data generation for index: 730
+2024/05/19 23:42:24 Initiating random data generation for index: 731
+2024/05/19 23:42:24 Initiating random data generation for index: 732
+2024/05/19 23:42:24 Initiating random data generation for index: 733
+2024/05/19 23:42:24 Initiating random data generation for index: 734
+2024/05/19 23:42:24 Initiating random data generation for index: 735
+2024/05/19 23:42:24 Initiating random data generation for index: 736
+2024/05/19 23:42:24 Initiating random data generation for index: 737
+2024/05/19 23:42:24 Initiating random data generation for index: 738
+2024/05/19 23:42:24 Initiating random data generation for index: 739
+2024/05/19 23:42:24 Initiating random data generation for index: 740
+2024/05/19 23:42:24 Initiating random data generation for index: 741
+2024/05/19 23:42:24 Initiating random data generation for index: 742
+2024/05/19 23:42:24 Initiating random data generation for index: 743
+2024/05/19 23:42:24 Initiating random data generation for index: 744
+2024/05/19 23:42:24 Initiating random data generation for index: 745
+2024/05/19 23:42:24 Initiating random data generation for index: 746
+2024/05/19 23:42:24 Initiating random data generation for index: 747
+2024/05/19 23:42:24 Initiating random data generation for index: 748
+2024/05/19 23:42:24 Initiating random data generation for index: 749
+2024/05/19 23:42:24 Initiating random data generation for index: 750
+2024/05/19 23:42:24 Initiating random data generation for index: 751
+2024/05/19 23:42:24 Initiating random data generation for index: 752
+2024/05/19 23:42:24 Initiating random data generation for index: 753
+2024/05/19 23:42:24 Initiating random data generation for index: 754
+2024/05/19 23:42:24 Initiating random data generation for index: 755
+2024/05/19 23:42:24 Initiating random data generation for index: 756
+2024/05/19 23:42:24 Initiating random data generation for index: 757
+2024/05/19 23:42:24 Initiating random data generation for index: 758
+2024/05/19 23:42:24 Initiating random data generation for index: 759
+2024/05/19 23:42:24 Initiating random data generation for index: 760
+2024/05/19 23:42:24 Initiating random data generation for index: 761
+2024/05/19 23:42:24 Initiating random data generation for index: 762
+2024/05/19 23:42:24 Initiating random data generation for index: 763
+2024/05/19 23:42:24 Initiating random data generation for index: 764
+2024/05/19 23:42:24 Initiating random data generation for index: 765
+2024/05/19 23:42:24 Initiating random data generation for index: 766
+2024/05/19 23:42:24 Initiating random data generation for index: 767
+2024/05/19 23:42:24 Initiating random data generation for index: 768
+2024/05/19 23:42:24 Initiating random data generation for index: 769
+2024/05/19 23:42:24 Initiating random data generation for index: 770
+2024/05/19 23:42:24 Initiating random data generation for index: 771
+2024/05/19 23:42:24 Initiating random data generation for index: 772
+2024/05/19 23:42:24 Initiating random data generation for index: 773
+2024/05/19 23:42:24 Initiating random data generation for index: 774
+2024/05/19 23:42:24 Initiating random data generation for index: 775
+2024/05/19 23:42:24 Initiating random data generation for index: 776
+2024/05/19 23:42:24 Initiating random data generation for index: 777
+2024/05/19 23:42:24 Initiating random data generation for index: 842
+2024/05/19 23:42:24 Initiating random data generation for index: 779
+2024/05/19 23:42:24 Initiating random data generation for index: 780
+2024/05/19 23:42:24 Initiating random data generation for index: 781
+2024/05/19 23:42:24 Initiating random data generation for index: 782
+2024/05/19 23:42:24 Initiating random data generation for index: 783
+2024/05/19 23:42:24 Initiating random data generation for index: 784
+2024/05/19 23:42:24 Initiating random data generation for index: 785
+2024/05/19 23:42:24 Initiating random data generation for index: 786
+2024/05/19 23:42:24 Initiating random data generation for index: 787
+2024/05/19 23:42:24 Initiating random data generation for index: 788
+2024/05/19 23:42:24 Initiating random data generation for index: 789
+2024/05/19 23:42:24 Initiating random data generation for index: 790
+2024/05/19 23:42:24 Initiating random data generation for index: 791
+2024/05/19 23:42:24 Initiating random data generation for index: 792
+2024/05/19 23:42:24 Initiating random data generation for index: 793
+2024/05/19 23:42:24 Initiating random data generation for index: 794
+2024/05/19 23:42:24 Initiating random data generation for index: 824
+2024/05/19 23:42:24 Initiating random data generation for index: 803
+2024/05/19 23:42:24 Initiating random data generation for index: 804
+2024/05/19 23:42:24 Initiating random data generation for index: 805
+2024/05/19 23:42:24 Initiating random data generation for index: 943
+2024/05/19 23:42:24 Initiating random data generation for index: 806
+2024/05/19 23:42:24 Initiating random data generation for index: 910
+2024/05/19 23:42:24 Initiating random data generation for index: 807
+2024/05/19 23:42:24 Initiating random data generation for index: 911
+2024/05/19 23:42:24 Initiating random data generation for index: 808
+2024/05/19 23:42:24 Initiating random data generation for index: 912
+2024/05/19 23:42:24 Initiating random data generation for index: 913
+2024/05/19 23:42:24 Initiating random data generation for index: 809
+2024/05/19 23:42:24 Initiating random data generation for index: 835
+2024/05/19 23:42:24 Initiating random data generation for index: 914
+2024/05/19 23:42:24 Initiating random data generation for index: 825
+2024/05/19 23:42:24 Initiating random data generation for index: 810
+2024/05/19 23:42:24 Initiating random data generation for index: 915
+2024/05/19 23:42:24 Initiating random data generation for index: 826
+2024/05/19 23:42:24 Initiating random data generation for index: 811
+2024/05/19 23:42:24 Initiating random data generation for index: 916
+2024/05/19 23:42:24 Initiating random data generation for index: 827
+2024/05/19 23:42:24 Initiating random data generation for index: 812
+2024/05/19 23:42:24 Initiating random data generation for index: 917
+2024/05/19 23:42:24 Initiating random data generation for index: 828
+2024/05/19 23:42:24 Initiating random data generation for index: 813
+2024/05/19 23:42:24 Initiating random data generation for index: 918
+2024/05/19 23:42:24 Initiating random data generation for index: 829
+2024/05/19 23:42:24 Initiating random data generation for index: 814
+2024/05/19 23:42:24 Initiating random data generation for index: 830
+2024/05/19 23:42:24 Initiating random data generation for index: 919
+2024/05/19 23:42:24 Initiating random data generation for index: 815
+2024/05/19 23:42:24 Initiating random data generation for index: 920
+2024/05/19 23:42:24 Initiating random data generation for index: 831
+2024/05/19 23:42:24 Initiating random data generation for index: 816
+2024/05/19 23:42:24 Initiating random data generation for index: 921
+2024/05/19 23:42:24 Initiating random data generation for index: 817
+2024/05/19 23:42:24 Initiating random data generation for index: 922
+2024/05/19 23:42:24 Initiating random data generation for index: 818
+2024/05/19 23:42:24 Initiating random data generation for index: 923
+2024/05/19 23:42:24 Initiating random data generation for index: 819
+2024/05/19 23:42:24 Initiating random data generation for index: 820
+2024/05/19 23:42:24 Initiating random data generation for index: 822
+2024/05/19 23:42:24 Initiating random data generation for index: 924
+2024/05/19 23:42:24 Initiating random data generation for index: 832
+2024/05/19 23:42:24 Initiating random data generation for index: 823
+2024/05/19 23:42:24 Initiating random data generation for index: 833
+2024/05/19 23:42:24 Initiating random data generation for index: 934
+2024/05/19 23:42:24 Initiating random data generation for index: 926
+2024/05/19 23:42:24 Initiating random data generation for index: 843
+2024/05/19 23:42:24 Initiating random data generation for index: 927
+2024/05/19 23:42:24 Initiating random data generation for index: 834
+2024/05/19 23:42:24 Initiating random data generation for index: 844
+2024/05/19 23:42:24 Initiating random data generation for index: 928
+2024/05/19 23:42:24 Initiating random data generation for index: 931
+2024/05/19 23:42:24 Initiating random data generation for index: 845
+2024/05/19 23:42:24 Initiating random data generation for index: 929
+2024/05/19 23:42:24 Initiating random data generation for index: 932
+2024/05/19 23:42:24 Initiating random data generation for index: 846
+2024/05/19 23:42:24 Initiating random data generation for index: 847
+2024/05/19 23:42:24 Initiating random data generation for index: 848
+2024/05/19 23:42:24 Initiating random data generation for index: 849
+2024/05/19 23:42:24 Initiating random data generation for index: 930
+2024/05/19 23:42:24 Initiating random data generation for index: 850
+2024/05/19 23:42:24 Initiating random data generation for index: 935
+2024/05/19 23:42:24 Initiating random data generation for index: 851
+2024/05/19 23:42:24 Initiating random data generation for index: 936
+2024/05/19 23:42:24 Initiating random data generation for index: 937
+2024/05/19 23:42:24 Initiating random data generation for index: 938
+2024/05/19 23:42:24 Initiating random data generation for index: 939
+2024/05/19 23:42:24 Initiating random data generation for index: 940
+2024/05/19 23:42:24 Initiating random data generation for index: 941
+2024/05/19 23:42:24 Initiating random data generation for index: 852
+2024/05/19 23:42:24 Initiating random data generation for index: 853
+2024/05/19 23:42:24 Initiating random data generation for index: 854
+2024/05/19 23:42:24 Initiating random data generation for index: 840
+2024/05/19 23:42:24 Initiating random data generation for index: 942
+2024/05/19 23:42:24 Initiating random data generation for index: 836
+2024/05/19 23:42:24 Initiating random data generation for index: 837
+2024/05/19 23:42:24 Initiating random data generation for index: 856
+2024/05/19 23:42:24 Initiating random data generation for index: 838
+2024/05/19 23:42:24 Initiating random data generation for index: 857
+2024/05/19 23:42:24 Initiating random data generation for index: 954
+2024/05/19 23:42:24 Initiating random data generation for index: 858
+2024/05/19 23:42:24 Initiating random data generation for index: 944
+2024/05/19 23:42:24 Initiating random data generation for index: 859
+2024/05/19 23:42:24 Initiating random data generation for index: 945
+2024/05/19 23:42:24 Initiating random data generation for index: 946
+2024/05/19 23:42:24 Initiating random data generation for index: 955
+2024/05/19 23:42:24 Initiating random data generation for index: 947
+2024/05/19 23:42:24 Initiating random data generation for index: 956
+2024/05/19 23:42:24 Initiating random data generation for index: 948
+2024/05/19 23:42:24 Initiating random data generation for index: 957
+2024/05/19 23:42:24 Initiating random data generation for index: 949
+2024/05/19 23:42:24 Initiating random data generation for index: 958
+2024/05/19 23:42:24 Initiating random data generation for index: 950
+2024/05/19 23:42:24 Initiating random data generation for index: 839
+2024/05/19 23:42:24 Initiating random data generation for index: 959
+2024/05/19 23:42:24 Initiating random data generation for index: 951
+2024/05/19 23:42:24 Initiating random data generation for index: 960
+2024/05/19 23:42:24 Initiating random data generation for index: 961
+2024/05/19 23:42:24 Generating 29575 numbers for index: 860
+2024/05/19 23:42:24 Initiating random data generation for index: 861
+2024/05/19 23:42:24 Initiating random data generation for index: 953
+2024/05/19 23:42:24 Initiating random data generation for index: 862
+2024/05/19 23:42:24 Initiating random data generation for index: 886
+2024/05/19 23:42:24 Initiating random data generation for index: 887
+2024/05/19 23:42:24 Initiating random data generation for index: 863
+2024/05/19 23:42:24 Initiating random data generation for index: 888
+2024/05/19 23:42:24 Initiating random data generation for index: 864
+2024/05/19 23:42:24 Generating 26143 numbers for index: 952
+2024/05/19 23:42:24 Initiating random data generation for index: 865
+2024/05/19 23:42:24 Initiating random data generation for index: 890
+2024/05/19 23:42:24 Initiating random data generation for index: 866
+2024/05/19 23:42:24 Initiating random data generation for index: 900
+2024/05/19 23:42:24 Initiating random data generation for index: 901
+2024/05/19 23:42:24 Initiating random data generation for index: 867
+2024/05/19 23:42:24 Initiating random data generation for index: 902
+2024/05/19 23:42:24 Initiating random data generation for index: 891
+2024/05/19 23:42:24 Initiating random data generation for index: 868
+2024/05/19 23:42:24 Initiating random data generation for index: 892
+2024/05/19 23:42:24 Initiating random data generation for index: 903
+2024/05/19 23:42:24 Initiating random data generation for index: 904
+2024/05/19 23:42:24 Generating 47846 numbers for index: 962
+2024/05/19 23:42:24 Initiating random data generation for index: 905
+2024/05/19 23:42:24 Initiating random data generation for index: 906
+2024/05/19 23:42:24 Initiating random data generation for index: 963
+2024/05/19 23:42:24 Initiating random data generation for index: 894
+2024/05/19 23:42:24 Initiating random data generation for index: 964
+2024/05/19 23:42:24 Initiating random data generation for index: 907
+2024/05/19 23:42:24 Initiating random data generation for index: 895
+2024/05/19 23:42:24 Initiating random data generation for index: 908
+2024/05/19 23:42:24 Initiating random data generation for index: 896
+2024/05/19 23:42:24 Initiating random data generation for index: 897
+2024/05/19 23:42:24 Generating 5012 numbers for index: 869
+2024/05/19 23:42:24 Initiating random data generation for index: 898
+2024/05/19 23:42:24 Initiating random data generation for index: 870
+2024/05/19 23:42:24 Generating 44891 numbers for index: 909
+2024/05/19 23:42:24 Initiating random data generation for index: 871
+2024/05/19 23:42:24 Initiating random data generation for index: 878
+2024/05/19 23:42:24 Initiating random data generation for index: 879
+2024/05/19 23:42:24 Initiating random data generation for index: 872
+2024/05/19 23:42:24 Initiating random data generation for index: 899
+2024/05/19 23:42:24 Initiating random data generation for index: 880
+2024/05/19 23:42:24 Initiating random data generation for index: 873
+2024/05/19 23:42:24 Initiating random data generation for index: 875
+2024/05/19 23:42:24 Initiating random data generation for index: 876
+2024/05/19 23:42:24 Generating 45668 numbers for index: 965
+2024/05/19 23:42:24 Initiating random data generation for index: 877
+2024/05/19 23:42:24 Initiating random data generation for index: 841
+2024/05/19 23:42:24 Initiating random data generation for index: 999
+2024/05/19 23:42:24 Initiating random data generation for index: 967
+2024/05/19 23:42:24 Initiating random data generation for index: 968
+2024/05/19 23:42:24 Initiating random data generation for index: 969
+2024/05/19 23:42:24 Initiating random data generation for index: 970
+2024/05/19 23:42:24 Initiating random data generation for index: 971
+2024/05/19 23:42:24 Initiating random data generation for index: 986
+2024/05/19 23:42:24 Initiating random data generation for index: 985
+2024/05/19 23:42:24 Initiating random data generation for index: 973
+2024/05/19 23:42:24 Generating 49202 numbers for index: 874
+2024/05/19 23:42:24 Initiating random data generation for index: 974
+2024/05/19 23:42:24 Initiating random data generation for index: 975
+2024/05/19 23:42:24 Initiating random data generation for index: 976
+2024/05/19 23:42:24 Initiating random data generation for index: 977
+2024/05/19 23:42:24 Initiating random data generation for index: 978
+2024/05/19 23:42:24 Initiating random data generation for index: 979
+2024/05/19 23:42:24 Initiating random data generation for index: 980
+2024/05/19 23:42:24 Initiating random data generation for index: 981
+2024/05/19 23:42:24 Initiating random data generation for index: 982
+2024/05/19 23:42:24 Initiating random data generation for index: 983
+2024/05/19 23:42:24 Generating 29672 numbers for index: 987
+2024/05/19 23:42:24 Initiating random data generation for index: 883
+2024/05/19 23:42:24 Generating 25846 numbers for index: 398
+2024/05/19 23:42:24 Initiating random data generation for index: 884
+2024/05/19 23:42:24 Initiating random data generation for index: 991
+2024/05/19 23:42:24 Generating 42245 numbers for index: 966
+2024/05/19 23:42:24 Initiating random data generation for index: 992
+2024/05/19 23:42:24 Initiating random data generation for index: 993
+2024/05/19 23:42:24 Generating 46698 numbers for index: 555
+2024/05/19 23:42:24 Generating 31965 numbers for index: 449
+2024/05/19 23:42:24 Generating 42049 numbers for index: 90
+2024/05/19 23:42:24 Generating 40242 numbers for index: 91
+2024/05/19 23:42:24 Generating 39059 numbers for index: 92
+2024/05/19 23:42:24 Generating 34082 numbers for index: 95
+2024/05/19 23:42:24 Initiating random data generation for index: 96
+2024/05/19 23:42:24 Initiating random data generation for index: 21
+2024/05/19 23:42:24 Initiating random data generation for index: 100
+2024/05/19 23:42:24 Generating 2936 numbers for index: 149
+2024/05/19 23:42:24 Initiating random data generation for index: 94
+2024/05/19 23:42:24 Generating 46751 numbers for index: 81
+2024/05/19 23:42:24 Generating 40591 numbers for index: 97
+2024/05/19 23:42:24 Generating 8231 numbers for index: 881
+2024/05/19 23:42:24 Generating 20574 numbers for index: 106
+2024/05/19 23:42:24 Generating 1825 numbers for index: 27
+2024/05/19 23:42:24 Generating 45432 numbers for index: 28
+2024/05/19 23:42:24 Generating 31758 numbers for index: 93
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_89.txt for index: 89
+2024/05/19 23:42:24 Generating 39633 numbers for index: 247
+2024/05/19 23:42:24 Generating 6304 numbers for index: 250
+2024/05/19 23:42:24 Generating 40792 numbers for index: 108
+2024/05/19 23:42:24 Generating 6449 numbers for index: 198
+2024/05/19 23:42:24 Generating 35113 numbers for index: 199
+2024/05/19 23:42:24 Generating 17216 numbers for index: 155
+2024/05/19 23:42:24 Generating 31913 numbers for index: 118
+2024/05/19 23:42:24 Generating 31456 numbers for index: 996
+2024/05/19 23:42:24 Generating 34124 numbers for index: 84
+2024/05/19 23:42:24 Generating 43784 numbers for index: 156
+2024/05/19 23:42:24 Generating 29024 numbers for index: 192
+2024/05/19 23:42:24 Generating 793 numbers for index: 109
+2024/05/19 23:42:24 Generating 49844 numbers for index: 125
+2024/05/19 23:42:24 Generating 15397 numbers for index: 73
+2024/05/19 23:42:24 Generating 25562 numbers for index: 234
+2024/05/19 23:42:24 Generating 5442 numbers for index: 235
+2024/05/19 23:42:24 Generating 30827 numbers for index: 236
+2024/05/19 23:42:24 Generating 42173 numbers for index: 237
+2024/05/19 23:42:24 Generating 24725 numbers for index: 201
+2024/05/19 23:42:24 Generating 7644 numbers for index: 238
+2024/05/19 23:42:24 Generating 4849 numbers for index: 239
+2024/05/19 23:42:24 Generating 8777 numbers for index: 222
+2024/05/19 23:42:24 Generating 13169 numbers for index: 223
+2024/05/19 23:42:24 Generating 33118 numbers for index: 224
+2024/05/19 23:42:24 Generating 34549 numbers for index: 225
+2024/05/19 23:42:24 Generating 596 numbers for index: 227
+2024/05/19 23:42:24 Generating 29206 numbers for index: 228
+2024/05/19 23:42:24 Generating 29303 numbers for index: 241
+2024/05/19 23:42:24 Generating 22717 numbers for index: 229
+2024/05/19 23:42:24 Generating 14694 numbers for index: 230
+2024/05/19 23:42:24 Generating 5520 numbers for index: 242
+2024/05/19 23:42:24 Generating 44929 numbers for index: 243
+2024/05/19 23:42:24 Generating 25688 numbers for index: 231
+2024/05/19 23:42:24 Generating 22825 numbers for index: 244
+2024/05/19 23:42:24 Generating 13623 numbers for index: 206
+2024/05/19 23:42:24 Generating 10251 numbers for index: 232
+2024/05/19 23:42:24 Generating 19984 numbers for index: 207
+2024/05/19 23:42:24 Generating 34059 numbers for index: 245
+2024/05/19 23:42:24 Generating 32848 numbers for index: 208
+2024/05/19 23:42:24 Generating 32004 numbers for index: 246
+2024/05/19 23:42:24 Generating 3100 numbers for index: 193
+2024/05/19 23:42:24 Generating 18144 numbers for index: 248
+2024/05/19 23:42:24 Generating 37057 numbers for index: 249
+2024/05/19 23:42:24 Generating 4826 numbers for index: 215
+2024/05/19 23:42:24 Generating 15455 numbers for index: 119
+2024/05/19 23:42:24 Generating 2476 numbers for index: 111
+2024/05/19 23:42:24 Generating 3763 numbers for index: 133
+2024/05/19 23:42:24 Generating 19526 numbers for index: 145
+2024/05/19 23:42:24 Generating 49443 numbers for index: 161
+2024/05/19 23:42:24 Generating 9628 numbers for index: 160
+2024/05/19 23:42:24 Generating 16517 numbers for index: 86
+2024/05/19 23:42:24 Generating 24692 numbers for index: 321
+2024/05/19 23:42:24 Initiating random data generation for index: 318
+2024/05/19 23:42:24 Generating 23205 numbers for index: 122
+2024/05/19 23:42:24 Generating 28997 numbers for index: 210
+2024/05/19 23:42:24 Generating 44559 numbers for index: 273
+2024/05/19 23:42:24 Generating 48549 numbers for index: 260
+2024/05/19 23:42:24 Generating 2549 numbers for index: 283
+2024/05/19 23:42:24 Initiating random data generation for index: 320
+2024/05/19 23:42:24 Generating 38128 numbers for index: 262
+2024/05/19 23:42:24 Generating 1311 numbers for index: 254
+2024/05/19 23:42:24 Generating 45703 numbers for index: 141
+2024/05/19 23:42:24 Generating 22394 numbers for index: 264
+2024/05/19 23:42:24 Generating 24957 numbers for index: 218
+2024/05/19 23:42:24 Generating 21467 numbers for index: 300
+2024/05/19 23:42:24 Generating 40954 numbers for index: 277
+2024/05/19 23:42:24 Generating 46762 numbers for index: 267
+2024/05/19 23:42:24 Generating 31836 numbers for index: 310
+2024/05/19 23:42:24 Generating 6608 numbers for index: 311
+2024/05/19 23:42:24 Generating 3599 numbers for index: 286
+2024/05/19 23:42:24 Generating 42668 numbers for index: 282
+2024/05/19 23:42:24 Generating 4625 numbers for index: 315
+2024/05/19 23:42:24 Generating 10003 numbers for index: 305
+2024/05/19 23:42:24 Generating 39321 numbers for index: 290
+2024/05/19 23:42:24 Generating 41741 numbers for index: 258
+2024/05/19 23:42:24 Generating 2848 numbers for index: 280
+2024/05/19 23:42:24 Generating 29909 numbers for index: 259
+2024/05/19 23:42:24 Generating 19832 numbers for index: 275
+2024/05/19 23:42:24 Initiating random data generation for index: 295
+2024/05/19 23:42:24 Initiating random data generation for index: 294
+2024/05/19 23:42:24 Generating 43086 numbers for index: 202
+2024/05/19 23:42:24 Generating 36589 numbers for index: 296
+2024/05/19 23:42:24 Generating 18607 numbers for index: 291
+2024/05/19 23:42:24 Generating 13252 numbers for index: 340
+2024/05/19 23:42:24 Generating 33222 numbers for index: 342
+2024/05/19 23:42:24 Generating 9119 numbers for index: 271
+2024/05/19 23:42:24 Generating 36360 numbers for index: 316
+2024/05/19 23:42:24 Generating 18811 numbers for index: 333
+2024/05/19 23:42:24 Generating 6841 numbers for index: 800
+2024/05/19 23:42:24 Generating 47862 numbers for index: 314
+2024/05/19 23:42:24 Generating 49635 numbers for index: 281
+2024/05/19 23:42:24 Generating 28557 numbers for index: 338
+2024/05/19 23:42:24 Generating 45323 numbers for index: 611
+2024/05/19 23:42:24 Generating 21755 numbers for index: 856
+2024/05/19 23:42:24 Generating 34327 numbers for index: 661
+2024/05/19 23:42:24 Generating 14237 numbers for index: 838
+2024/05/19 23:42:24 Generating 43874 numbers for index: 955
+2024/05/19 23:42:24 Initiating random data generation for index: 363
+2024/05/19 23:42:24 Generating 39368 numbers for index: 363
+2024/05/19 23:42:24 Generating 9865 numbers for index: 956
+2024/05/19 23:42:24 Generating 482 numbers for index: 948
+2024/05/19 23:42:24 Generating 25266 numbers for index: 957
+2024/05/19 23:42:24 Generating 24160 numbers for index: 949
+2024/05/19 23:42:24 Generating 48991 numbers for index: 958
+2024/05/19 23:42:24 Generating 45790 numbers for index: 592
+2024/05/19 23:42:24 Generating 49595 numbers for index: 682
+2024/05/19 23:42:24 Generating 16005 numbers for index: 683
+2024/05/19 23:42:24 Generating 37838 numbers for index: 695
+2024/05/19 23:42:24 Generating 12181 numbers for index: 887
+2024/05/19 23:42:24 Generating 43117 numbers for index: 960
+2024/05/19 23:42:24 Generating 8814 numbers for index: 573
+2024/05/19 23:42:24 Generating 6299 numbers for index: 343
+2024/05/19 23:42:24 Generating 49713 numbers for index: 890
+2024/05/19 23:42:24 Generating 43810 numbers for index: 684
+2024/05/19 23:42:24 Generating 32468 numbers for index: 685
+2024/05/19 23:42:24 Generating 18337 numbers for index: 866
+2024/05/19 23:42:24 Generating 17369 numbers for index: 900
+2024/05/19 23:42:24 Generating 25199 numbers for index: 901
+2024/05/19 23:42:24 Generating 17185 numbers for index: 867
+2024/05/19 23:42:24 Generating 42444 numbers for index: 686
+2024/05/19 23:42:24 Generating 9947 numbers for index: 868
+2024/05/19 23:42:24 Generating 42729 numbers for index: 658
+2024/05/19 23:42:24 Generating 47474 numbers for index: 687
+2024/05/19 23:42:24 Generating 14425 numbers for index: 904
+2024/05/19 23:42:24 Generating 28567 numbers for index: 691
+2024/05/19 23:42:24 Generating 48047 numbers for index: 905
+2024/05/19 23:42:24 Generating 33548 numbers for index: 892
+2024/05/19 23:42:24 Generating 42411 numbers for index: 615
+2024/05/19 23:42:24 Generating 618 numbers for index: 906
+2024/05/19 23:42:24 Generating 21118 numbers for index: 692
+2024/05/19 23:42:24 Generating 7404 numbers for index: 963
+2024/05/19 23:42:24 Generating 30551 numbers for index: 894
+2024/05/19 23:42:24 Generating 31241 numbers for index: 699
+2024/05/19 23:42:24 Generating 12567 numbers for index: 908
+2024/05/19 23:42:24 Generating 30345 numbers for index: 622
+2024/05/19 23:42:24 Generating 11065 numbers for index: 693
+2024/05/19 23:42:24 Generating 36110 numbers for index: 897
+2024/05/19 23:42:24 Generating 48442 numbers for index: 346
+2024/05/19 23:42:24 Generating 19921 numbers for index: 348
+2024/05/19 23:42:24 Generating 49794 numbers for index: 351
+2024/05/19 23:42:24 Generating 13770 numbers for index: 345
+2024/05/19 23:42:24 Generating 44185 numbers for index: 352
+2024/05/19 23:42:24 Generating 46403 numbers for index: 871
+2024/05/19 23:42:24 Generating 28571 numbers for index: 879
+2024/05/19 23:42:24 Generating 38874 numbers for index: 872
+2024/05/19 23:42:24 Generating 6180 numbers for index: 623
+2024/05/19 23:42:24 Generating 48155 numbers for index: 899
+2024/05/19 23:42:24 Generating 5611 numbers for index: 880
+2024/05/19 23:42:24 Generating 14441 numbers for index: 652
+2024/05/19 23:42:24 Generating 10494 numbers for index: 877
+2024/05/19 23:42:24 Generating 28013 numbers for index: 674
+2024/05/19 23:42:24 Generating 21285 numbers for index: 999
+2024/05/19 23:42:24 Generating 33626 numbers for index: 593
+2024/05/19 23:42:24 Generating 3723 numbers for index: 354
+2024/05/19 23:42:24 Generating 40470 numbers for index: 353
+2024/05/19 23:42:24 Generating 22552 numbers for index: 973
+2024/05/19 23:42:24 Generating 3420 numbers for index: 744
+2024/05/19 23:42:24 Generating 30649 numbers for index: 974
+2024/05/19 23:42:24 Generating 28409 numbers for index: 986
+2024/05/19 23:42:24 Generating 6297 numbers for index: 975
+2024/05/19 23:42:24 Generating 24566 numbers for index: 976
+2024/05/19 23:42:24 Generating 12426 numbers for index: 178
+2024/05/19 23:42:24 Generating 39724 numbers for index: 361
+2024/05/19 23:42:24 Generating 42539 numbers for index: 334
+2024/05/19 23:42:24 Generating 10166 numbers for index: 457
+2024/05/19 23:42:24 Generating 49877 numbers for index: 978
+2024/05/19 23:42:24 Generating 15592 numbers for index: 350
+2024/05/19 23:42:24 Generating 36437 numbers for index: 183
+2024/05/19 23:42:24 Generating 11665 numbers for index: 168
+2024/05/19 23:42:24 Generating 17316 numbers for index: 186
+2024/05/19 23:42:24 Generating 47870 numbers for index: 51
+2024/05/19 23:42:24 Generating 48225 numbers for index: 163
+2024/05/19 23:42:24 Generating 12275 numbers for index: 169
+2024/05/19 23:42:24 Generating 40373 numbers for index: 172
+2024/05/19 23:42:24 Generating 7752 numbers for index: 187
+2024/05/19 23:42:24 Generating 25059 numbers for index: 176
+2024/05/19 23:42:24 Initiating random data generation for index: 367
+2024/05/19 23:42:24 Generating 24082 numbers for index: 191
+2024/05/19 23:42:24 Generating 44762 numbers for index: 184
+2024/05/19 23:42:24 Generating 44237 numbers for index: 72
+2024/05/19 23:42:24 Generating 31538 numbers for index: 369
+2024/05/19 23:42:24 Initiating random data generation for index: 371
+2024/05/19 23:42:24 Initiating random data generation for index: 375
+2024/05/19 23:42:24 Initiating random data generation for index: 513
+2024/05/19 23:42:24 Initiating random data generation for index: 378
+2024/05/19 23:42:24 Generating 35500 numbers for index: 382
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_324.txt for index: 324
+2024/05/19 23:42:24 Generating 17568 numbers for index: 409
+2024/05/19 23:42:24 Generating 1643 numbers for index: 594
+2024/05/19 23:42:24 Initiating random data generation for index: 595
+2024/05/19 23:42:24 Generating 8518 numbers for index: 415
+2024/05/19 23:42:24 Generating 31849 numbers for index: 195
+2024/05/19 23:42:24 Generating 35114 numbers for index: 422
+2024/05/19 23:42:24 Generating 16502 numbers for index: 467
+2024/05/19 23:42:24 Generating 39441 numbers for index: 565
+2024/05/19 23:42:24 Generating 25274 numbers for index: 578
+2024/05/19 23:42:24 Generating 28995 numbers for index: 583
+2024/05/19 23:42:24 Generating 22324 numbers for index: 426
+2024/05/19 23:42:24 Generating 6084 numbers for index: 567
+2024/05/19 23:42:24 Generating 39723 numbers for index: 490
+2024/05/19 23:42:24 Generating 11241 numbers for index: 411
+2024/05/19 23:42:24 Generating 13691 numbers for index: 465
+2024/05/19 23:42:24 Generating 28940 numbers for index: 580
+2024/05/19 23:42:24 Generating 47968 numbers for index: 581
+2024/05/19 23:42:24 Generating 5656 numbers for index: 430
+2024/05/19 23:42:24 Generating 16709 numbers for index: 466
+2024/05/19 23:42:24 Generating 29931 numbers for index: 528
+2024/05/19 23:42:24 Generating 42824 numbers for index: 508
+2024/05/19 23:42:24 Generating 46829 numbers for index: 504
+2024/05/19 23:42:24 Generating 39640 numbers for index: 410
+2024/05/19 23:42:24 Generating 25244 numbers for index: 480
+2024/05/19 23:42:24 Generating 15267 numbers for index: 407
+2024/05/19 23:42:24 Generating 8513 numbers for index: 472
+2024/05/19 23:42:24 Generating 27941 numbers for index: 413
+2024/05/19 23:42:24 Generating 34915 numbers for index: 570
+2024/05/19 23:42:24 Generating 29895 numbers for index: 574
+2024/05/19 23:42:24 Generating 12746 numbers for index: 404
+2024/05/19 23:42:24 Generating 36792 numbers for index: 587
+2024/05/19 23:42:24 Generating 49640 numbers for index: 431
+2024/05/19 23:42:24 Generating 43149 numbers for index: 576
+2024/05/19 23:42:24 Generating 34911 numbers for index: 778
+2024/05/19 23:42:24 Generating 10475 numbers for index: 705
+2024/05/19 23:42:24 Generating 39324 numbers for index: 961
+2024/05/19 23:42:24 Generating 35225 numbers for index: 993
+2024/05/19 23:42:24 Generating 32783 numbers for index: 344
+2024/05/19 23:42:24 Generating 312 numbers for index: 96
+2024/05/19 23:42:24 Generating 20648 numbers for index: 709
+2024/05/19 23:42:24 Generating 27845 numbers for index: 100
+2024/05/19 23:42:24 Generating 2197 numbers for index: 985
+2024/05/19 23:42:24 Generating 25749 numbers for index: 94
+2024/05/19 23:42:24 Generating 18743 numbers for index: 653
+2024/05/19 23:42:24 Generating 37841 numbers for index: 60
+2024/05/19 23:42:24 Generating 25350 numbers for index: 498
+2024/05/19 23:42:24 Generating 7558 numbers for index: 710
+2024/05/19 23:42:24 Generating 42657 numbers for index: 711
+2024/05/19 23:42:24 Generating 10251 numbers for index: 712
+2024/05/19 23:42:24 Generating 12132 numbers for index: 679
+2024/05/19 23:42:24 Generating 16325 numbers for index: 971
+2024/05/19 23:42:24 Generating 3016 numbers for index: 841
+2024/05/19 23:42:24 Generating 37067 numbers for index: 362
+2024/05/19 23:42:24 Generating 30856 numbers for index: 873
+2024/05/19 23:42:24 Generating 20537 numbers for index: 605
+2024/05/19 23:42:24 Generating 8995 numbers for index: 714
+2024/05/19 23:42:24 Generating 28322 numbers for index: 805
+2024/05/19 23:42:24 Generating 29563 numbers for index: 811
+2024/05/19 23:42:24 Initiating random data generation for index: 596
+2024/05/19 23:42:24 Generating 39597 numbers for index: 547
+2024/05/19 23:42:24 Generating 6727 numbers for index: 917
+2024/05/19 23:42:24 Generating 33483 numbers for index: 554
+2024/05/19 23:42:24 Generating 39419 numbers for index: 920
+2024/05/19 23:42:24 Generating 16503 numbers for index: 924
+2024/05/19 23:42:24 Generating 30281 numbers for index: 21
+2024/05/19 23:42:24 Generating 39567 numbers for index: 644
+2024/05/19 23:42:24 Generating 6855 numbers for index: 665
+2024/05/19 23:42:24 Generating 41178 numbers for index: 706
+2024/05/19 23:42:24 Generating 21624 numbers for index: 694
+2024/05/19 23:42:24 Generating 36979 numbers for index: 821
+2024/05/19 23:42:24 Generating 12214 numbers for index: 716
+2024/05/19 23:42:24 Initiating random data generation for index: 619
+2024/05/19 23:42:24 Initiating random data generation for index: 618
+2024/05/19 23:42:24 Initiating random data generation for index: 620
+2024/05/19 23:42:24 Generating 43274 numbers for index: 671
+2024/05/19 23:42:24 Initiating random data generation for index: 672
+2024/05/19 23:42:24 Generating 35082 numbers for index: 673
+2024/05/19 23:42:24 Generating 28666 numbers for index: 616
+2024/05/19 23:42:24 Generating 29695 numbers for index: 542
+2024/05/19 23:42:24 Generating 2672 numbers for index: 536
+2024/05/19 23:42:24 Generating 5649 numbers for index: 548
+2024/05/19 23:42:24 Generating 22952 numbers for index: 704
+2024/05/19 23:42:24 Generating 36499 numbers for index: 840
+2024/05/19 23:42:24 Generating 10045 numbers for index: 515
+2024/05/19 23:42:24 Generating 17305 numbers for index: 419
+2024/05/19 23:42:24 Generating 46750 numbers for index: 537
+2024/05/19 23:42:24 Generating 39589 numbers for index: 516
+2024/05/19 23:42:24 Generating 15297 numbers for index: 517
+2024/05/19 23:42:24 Generating 25010 numbers for index: 518
+2024/05/19 23:42:24 Generating 311 numbers for index: 519
+2024/05/19 23:42:24 Generating 39260 numbers for index: 487
+2024/05/19 23:42:24 Generating 21107 numbers for index: 520
+2024/05/19 23:42:24 Generating 42536 numbers for index: 521
+2024/05/19 23:42:24 Generating 39856 numbers for index: 522
+2024/05/19 23:42:24 Generating 34770 numbers for index: 489
+2024/05/19 23:42:24 Generating 17591 numbers for index: 421
+2024/05/19 23:42:24 Generating 5447 numbers for index: 562
+2024/05/19 23:42:24 Generating 35988 numbers for index: 499
+2024/05/19 23:42:24 Generating 25266 numbers for index: 459
+2024/05/19 23:42:24 Generating 46548 numbers for index: 423
+2024/05/19 23:42:24 Generating 2453 numbers for index: 460
+2024/05/19 23:42:24 Generating 49927 numbers for index: 561
+2024/05/19 23:42:24 Generating 29324 numbers for index: 646
+2024/05/19 23:42:24 Generating 3063 numbers for index: 647
+2024/05/19 23:42:24 Generating 28421 numbers for index: 650
+2024/05/19 23:42:24 Generating 7156 numbers for index: 648
+2024/05/19 23:42:24 Generating 47547 numbers for index: 649
+2024/05/19 23:42:24 Generating 40555 numbers for index: 667
+2024/05/19 23:42:24 Generating 5016 numbers for index: 624
+2024/05/19 23:42:24 Generating 15449 numbers for index: 424
+2024/05/19 23:42:24 Generating 25344 numbers for index: 664
+2024/05/19 23:42:24 Generating 19589 numbers for index: 588
+2024/05/19 23:42:24 Generating 48867 numbers for index: 668
+2024/05/19 23:42:24 Generating 28576 numbers for index: 655
+2024/05/19 23:42:24 Generating 46787 numbers for index: 591
+2024/05/19 23:42:24 Generating 5002 numbers for index: 669
+2024/05/19 23:42:24 Generating 16898 numbers for index: 656
+2024/05/19 23:42:24 Generating 43901 numbers for index: 625
+2024/05/19 23:42:24 Generating 32591 numbers for index: 626
+2024/05/19 23:42:24 Generating 6561 numbers for index: 627
+2024/05/19 23:42:24 Generating 28414 numbers for index: 629
+2024/05/19 23:42:24 Generating 44180 numbers for index: 630
+2024/05/19 23:42:24 Generating 10724 numbers for index: 631
+2024/05/19 23:42:24 Generating 32095 numbers for index: 632
+2024/05/19 23:42:24 Generating 35556 numbers for index: 633
+2024/05/19 23:42:24 Generating 14734 numbers for index: 635
+2024/05/19 23:42:24 Generating 48689 numbers for index: 636
+2024/05/19 23:42:24 Generating 27039 numbers for index: 637
+2024/05/19 23:42:24 Generating 12301 numbers for index: 638
+2024/05/19 23:42:24 Generating 14922 numbers for index: 539
+2024/05/19 23:42:24 Generating 36520 numbers for index: 461
+2024/05/19 23:42:24 Generating 43611 numbers for index: 639
+2024/05/19 23:42:24 Generating 32571 numbers for index: 640
+2024/05/19 23:42:24 Generating 25962 numbers for index: 458
+2024/05/19 23:42:24 Generating 33734 numbers for index: 651
+2024/05/19 23:42:24 Generating 30212 numbers for index: 654
+2024/05/19 23:42:24 Generating 19604 numbers for index: 659
+2024/05/19 23:42:24 Generating 22784 numbers for index: 660
+2024/05/19 23:42:24 Generating 11041 numbers for index: 641
+2024/05/19 23:42:24 Generating 45976 numbers for index: 643
+2024/05/19 23:42:24 Generating 1106 numbers for index: 657
+2024/05/19 23:42:24 Generating 21878 numbers for index: 500
+2024/05/19 23:42:24 Generating 18924 numbers for index: 645
+2024/05/19 23:42:24 Generating 42579 numbers for index: 857
+2024/05/19 23:42:24 Generating 32244 numbers for index: 954
+2024/05/19 23:42:24 Generating 15988 numbers for index: 858
+2024/05/19 23:42:24 Generating 11386 numbers for index: 944
+2024/05/19 23:42:24 Generating 3337 numbers for index: 859
+2024/05/19 23:42:24 Generating 45263 numbers for index: 946
+2024/05/19 23:42:24 Generating 24278 numbers for index: 945
+2024/05/19 23:42:24 Generating 12762 numbers for index: 947
+2024/05/19 23:42:24 Generating 6247 numbers for index: 681
+2024/05/19 23:42:24 Generating 5079 numbers for index: 950
+2024/05/19 23:42:24 Generating 10566 numbers for index: 680
+2024/05/19 23:42:24 Generating 22112 numbers for index: 839
+2024/05/19 23:42:24 Generating 47077 numbers for index: 959
+2024/05/19 23:42:24 Generating 28145 numbers for index: 951
+2024/05/19 23:42:24 Generating 47664 numbers for index: 953
+2024/05/19 23:42:24 Generating 48142 numbers for index: 862
+2024/05/19 23:42:24 Generating 8050 numbers for index: 886
+2024/05/19 23:42:24 Generating 18511 numbers for index: 863
+2024/05/19 23:42:24 Generating 387 numbers for index: 888
+2024/05/19 23:42:24 Generating 40443 numbers for index: 865
+2024/05/19 23:42:24 Generating 5590 numbers for index: 698
+2024/05/19 23:42:24 Generating 13443 numbers for index: 662
+2024/05/19 23:42:24 Generating 11999 numbers for index: 902
+2024/05/19 23:42:24 Generating 12105 numbers for index: 891
+2024/05/19 23:42:24 Generating 18328 numbers for index: 666
+2024/05/19 23:42:24 Generating 37963 numbers for index: 903
+2024/05/19 23:42:24 Generating 5570 numbers for index: 688
+2024/05/19 23:42:24 Generating 35582 numbers for index: 689
+2024/05/19 23:42:24 Generating 7634 numbers for index: 690
+2024/05/19 23:42:24 Generating 16190 numbers for index: 964
+2024/05/19 23:42:24 Generating 46023 numbers for index: 907
+2024/05/19 23:42:24 Generating 41215 numbers for index: 895
+2024/05/19 23:42:24 Generating 39109 numbers for index: 621
+2024/05/19 23:42:24 Generating 23310 numbers for index: 896
+2024/05/19 23:42:24 Generating 48800 numbers for index: 700
+2024/05/19 23:42:24 Generating 34278 numbers for index: 898
+2024/05/19 23:42:24 Generating 44520 numbers for index: 870
+2024/05/19 23:42:24 Generating 5364 numbers for index: 875
+2024/05/19 23:42:24 Generating 24107 numbers for index: 876
+2024/05/19 23:42:24 Generating 33964 numbers for index: 968
+2024/05/19 23:42:24 Generating 11093 numbers for index: 969
+2024/05/19 23:42:24 Generating 32999 numbers for index: 560
+2024/05/19 23:42:24 Generating 30134 numbers for index: 701
+2024/05/19 23:42:24 Generating 43693 numbers for index: 335
+2024/05/19 23:42:24 Generating 45298 numbers for index: 977
+2024/05/19 23:42:24 Generating 45062 numbers for index: 347
+2024/05/19 23:42:24 Generating 6932 numbers for index: 188
+2024/05/19 23:42:24 Generating 43607 numbers for index: 702
+2024/05/19 23:42:24 Generating 10492 numbers for index: 697
+2024/05/19 23:42:24 Generating 19796 numbers for index: 861
+2024/05/19 23:42:24 Generating 737 numbers for index: 676
+2024/05/19 23:42:24 Generating 740 numbers for index: 428
+2024/05/19 23:42:24 Generating 48477 numbers for index: 979
+2024/05/19 23:42:24 Generating 19832 numbers for index: 980
+2024/05/19 23:42:24 Generating 8736 numbers for index: 981
+2024/05/19 23:42:24 Generating 15264 numbers for index: 501
+2024/05/19 23:42:24 Generating 42460 numbers for index: 983
+2024/05/19 23:42:24 Generating 40811 numbers for index: 864
+2024/05/19 23:42:24 Generating 31406 numbers for index: 883
+2024/05/19 23:42:24 Generating 27649 numbers for index: 462
+2024/05/19 23:42:24 Generating 4546 numbers for index: 884
+2024/05/19 23:42:24 Generating 26012 numbers for index: 540
+2024/05/19 23:42:24 Generating 17781 numbers for index: 425
+2024/05/19 23:42:24 Generating 38185 numbers for index: 991
+2024/05/19 23:42:24 Initiating random data generation for index: 597
+2024/05/19 23:42:24 Generating 26589 numbers for index: 584
+2024/05/19 23:42:24 Generating 9827 numbers for index: 678
+2024/05/19 23:42:24 Generating 27575 numbers for index: 476
+2024/05/19 23:42:24 Generating 21831 numbers for index: 715
+2024/05/19 23:42:24 Generating 4964 numbers for index: 853
+2024/05/19 23:42:24 Generating 44586 numbers for index: 725
+2024/05/19 23:42:24 Generating 23074 numbers for index: 836
+2024/05/19 23:42:24 Generating 42762 numbers for index: 722
+2024/05/19 23:42:24 Generating 49836 numbers for index: 820
+2024/05/19 23:42:24 Generating 45689 numbers for index: 937
+2024/05/19 23:42:24 Generating 42954 numbers for index: 748
+2024/05/19 23:42:24 Generating 11295 numbers for index: 318
+2024/05/19 23:42:24 Generating 27649 numbers for index: 845
+2024/05/19 23:42:24 Generating 3381 numbers for index: 837
+2024/05/19 23:42:24 Generating 30657 numbers for index: 929
+2024/05/19 23:42:24 Generating 313 numbers for index: 932
+2024/05/19 23:42:24 Generating 13237 numbers for index: 967
+2024/05/19 23:42:24 Generating 17706 numbers for index: 847
+2024/05/19 23:42:24 Generating 15231 numbers for index: 935
+2024/05/19 23:42:24 Generating 46519 numbers for index: 707
+2024/05/19 23:42:24 Generating 42706 numbers for index: 642
+2024/05/19 23:42:24 Generating 11870 numbers for index: 992
+2024/05/19 23:42:24 Generating 17468 numbers for index: 708
+2024/05/19 23:42:24 Generating 31116 numbers for index: 634
+2024/05/19 23:42:24 Generating 2145 numbers for index: 851
+2024/05/19 23:42:24 Generating 4231 numbers for index: 849
+2024/05/19 23:42:24 Generating 15809 numbers for index: 936
+2024/05/19 23:42:24 Generating 35471 numbers for index: 939
+2024/05/19 23:42:24 Generating 29267 numbers for index: 930
+2024/05/19 23:42:24 Generating 9837 numbers for index: 850
+2024/05/19 23:42:24 Generating 32967 numbers for index: 940
+2024/05/19 23:42:24 Generating 40195 numbers for index: 938
+2024/05/19 23:42:24 Generating 8645 numbers for index: 719
+2024/05/19 23:42:24 Generating 45018 numbers for index: 941
+2024/05/19 23:42:24 Generating 30174 numbers for index: 854
+2024/05/19 23:42:24 Generating 12589 numbers for index: 852
+2024/05/19 23:42:24 Generating 7894 numbers for index: 818
+2024/05/19 23:42:24 Generating 4195 numbers for index: 942
+2024/05/19 23:42:24 Generating 44765 numbers for index: 970
+2024/05/19 23:42:24 Generating 41563 numbers for index: 619
+2024/05/19 23:42:24 Generating 3918 numbers for index: 628
+2024/05/19 23:42:24 Generating 41136 numbers for index: 720
+2024/05/19 23:42:24 Generating 37974 numbers for index: 721
+2024/05/19 23:42:24 Generating 26051 numbers for index: 934
+2024/05/19 23:42:24 Generating 1418 numbers for index: 733
+2024/05/19 23:42:24 Generating 20491 numbers for index: 729
+2024/05/19 23:42:24 Generating 8916 numbers for index: 731
+2024/05/19 23:42:24 Generating 9267 numbers for index: 438
+2024/05/19 23:42:24 Generating 44854 numbers for index: 735
+2024/05/19 23:42:24 Generating 20900 numbers for index: 736
+2024/05/19 23:42:24 Generating 40669 numbers for index: 713
+2024/05/19 23:42:24 Generating 22457 numbers for index: 433
+2024/05/19 23:42:24 Generating 39695 numbers for index: 608
+2024/05/19 23:42:24 Generating 18556 numbers for index: 703
+2024/05/19 23:42:24 Generating 44996 numbers for index: 747
+2024/05/19 23:42:24 Generating 44006 numbers for index: 749
+2024/05/19 23:42:24 Generating 36636 numbers for index: 771
+2024/05/19 23:42:24 Generating 30057 numbers for index: 750
+2024/05/19 23:42:24 Generating 118 numbers for index: 751
+2024/05/19 23:42:24 Generating 13648 numbers for index: 752
+2024/05/19 23:42:24 Generating 19158 numbers for index: 753
+2024/05/19 23:42:24 Generating 9782 numbers for index: 772
+2024/05/19 23:42:24 Generating 49933 numbers for index: 755
+2024/05/19 23:42:24 Generating 47069 numbers for index: 756
+2024/05/19 23:42:24 Generating 47741 numbers for index: 773
+2024/05/19 23:42:24 Generating 3158 numbers for index: 757
+2024/05/19 23:42:24 Generating 33225 numbers for index: 758
+2024/05/19 23:42:24 Generating 36094 numbers for index: 737
+2024/05/19 23:42:24 Generating 5608 numbers for index: 738
+2024/05/19 23:42:24 Generating 32899 numbers for index: 775
+2024/05/19 23:42:24 Generating 4617 numbers for index: 739
+2024/05/19 23:42:24 Generating 6535 numbers for index: 776
+2024/05/19 23:42:24 Generating 8248 numbers for index: 741
+2024/05/19 23:42:24 Generating 4068 numbers for index: 777
+2024/05/19 23:42:24 Generating 30883 numbers for index: 842
+2024/05/19 23:42:24 Generating 21720 numbers for index: 742
+2024/05/19 23:42:24 Generating 6395 numbers for index: 779
+2024/05/19 23:42:24 Generating 9686 numbers for index: 743
+2024/05/19 23:42:24 Generating 9911 numbers for index: 781
+2024/05/19 23:42:24 Generating 13346 numbers for index: 782
+2024/05/19 23:42:24 Generating 30194 numbers for index: 783
+2024/05/19 23:42:24 Generating 23840 numbers for index: 784
+2024/05/19 23:42:24 Generating 46352 numbers for index: 785
+2024/05/19 23:42:24 Generating 42384 numbers for index: 792
+2024/05/19 23:42:24 Generating 4376 numbers for index: 787
+2024/05/19 23:42:24 Generating 3191 numbers for index: 793
+2024/05/19 23:42:24 Generating 47167 numbers for index: 788
+2024/05/19 23:42:24 Generating 36382 numbers for index: 789
+2024/05/19 23:42:24 Generating 26468 numbers for index: 745
+2024/05/19 23:42:24 Generating 47293 numbers for index: 746
+2024/05/19 23:42:24 Generating 49573 numbers for index: 790
+2024/05/19 23:42:24 Generating 1213 numbers for index: 791
+2024/05/19 23:42:24 Generating 42960 numbers for index: 806
+2024/05/19 23:42:24 Generating 15059 numbers for index: 910
+2024/05/19 23:42:24 Generating 23791 numbers for index: 807
+2024/05/19 23:42:24 Generating 82 numbers for index: 911
+2024/05/19 23:42:24 Generating 10691 numbers for index: 808
+2024/05/19 23:42:24 Generating 7372 numbers for index: 912
+2024/05/19 23:42:24 Generating 38553 numbers for index: 913
+2024/05/19 23:42:24 Generating 17342 numbers for index: 809
+2024/05/19 23:42:24 Generating 6478 numbers for index: 835
+2024/05/19 23:42:24 Generating 13998 numbers for index: 914
+2024/05/19 23:42:24 Generating 26391 numbers for index: 825
+2024/05/19 23:42:24 Generating 8324 numbers for index: 810
+2024/05/19 23:42:24 Generating 18896 numbers for index: 794
+2024/05/19 23:42:24 Generating 38975 numbers for index: 826
+2024/05/19 23:42:24 Generating 21649 numbers for index: 824
+2024/05/19 23:42:24 Generating 28140 numbers for index: 803
+2024/05/19 23:42:24 Generating 5785 numbers for index: 804
+2024/05/19 23:42:24 Generating 26184 numbers for index: 916
+2024/05/19 23:42:24 Generating 46663 numbers for index: 827
+2024/05/19 23:42:24 Generating 25187 numbers for index: 943
+2024/05/19 23:42:24 Generating 38749 numbers for index: 812
+2024/05/19 23:42:24 Generating 43893 numbers for index: 919
+2024/05/19 23:42:24 Generating 4884 numbers for index: 815
+2024/05/19 23:42:24 Generating 39503 numbers for index: 557
+2024/05/19 23:42:24 Generating 987 numbers for index: 828
+2024/05/19 23:42:24 Generating 21102 numbers for index: 813
+2024/05/19 23:42:24 Generating 11496 numbers for index: 918
+2024/05/19 23:42:24 Generating 19201 numbers for index: 829
+2024/05/19 23:42:24 Generating 31298 numbers for index: 814
+2024/05/19 23:42:24 Generating 36785 numbers for index: 830
+2024/05/19 23:42:24 Generating 5442 numbers for index: 764
+2024/05/19 23:42:24 Generating 32786 numbers for index: 765
+2024/05/19 23:42:24 Generating 23168 numbers for index: 766
+2024/05/19 23:42:24 Generating 33640 numbers for index: 767
+2024/05/19 23:42:24 Generating 34593 numbers for index: 768
+2024/05/19 23:42:24 Generating 46894 numbers for index: 769
+2024/05/19 23:42:24 Generating 2610 numbers for index: 823
+2024/05/19 23:42:24 Generating 46381 numbers for index: 923
+2024/05/19 23:42:24 Generating 12374 numbers for index: 819
+2024/05/19 23:42:24 Generating 31698 numbers for index: 822
+2024/05/19 23:42:24 Generating 33037 numbers for index: 831
+2024/05/19 23:42:24 Generating 28266 numbers for index: 439
+2024/05/19 23:42:24 Generating 6621 numbers for index: 833
+2024/05/19 23:42:24 Generating 9949 numbers for index: 834
+2024/05/19 23:42:24 Generating 24899 numbers for index: 360
+2024/05/19 23:42:24 Generating 34584 numbers for index: 366
+2024/05/19 23:42:24 Generating 22293 numbers for index: 358
+2024/05/19 23:42:24 Generating 12474 numbers for index: 915
+2024/05/19 23:42:24 Generating 4025 numbers for index: 596
+2024/05/19 23:42:24 Generating 39795 numbers for index: 534
+2024/05/19 23:42:24 Generating 15926 numbers for index: 734
+2024/05/19 23:42:24 Generating 28436 numbers for index: 723
+2024/05/19 23:42:24 Generating 41905 numbers for index: 727
+2024/05/19 23:42:24 Generating 7958 numbers for index: 770
+2024/05/19 23:42:24 Generating 30673 numbers for index: 732
+2024/05/19 23:42:24 Generating 10126 numbers for index: 726
+2024/05/19 23:42:24 Generating 45731 numbers for index: 728
+2024/05/19 23:42:24 Generating 10383 numbers for index: 724
+2024/05/19 23:42:24 Generating 32998 numbers for index: 763
+2024/05/19 23:42:24 Generating 18999 numbers for index: 696
+2024/05/19 23:42:24 Generating 37374 numbers for index: 760
+2024/05/19 23:42:24 Generating 10100 numbers for index: 718
+2024/05/19 23:42:24 Generating 46065 numbers for index: 663
+2024/05/19 23:42:24 Generating 25949 numbers for index: 878
+2024/05/19 23:42:24 Generating 214 numbers for index: 759
+2024/05/19 23:42:24 Generating 27093 numbers for index: 761
+2024/05/19 23:42:24 Generating 1181 numbers for index: 762
+2024/05/19 23:42:24 Generating 29261 numbers for index: 367
+2024/05/19 23:42:24 Generating 39403 numbers for index: 371
+2024/05/19 23:42:24 Generating 35788 numbers for index: 375
+2024/05/19 23:42:24 Generating 44158 numbers for index: 513
+2024/05/19 23:42:24 Generating 13986 numbers for index: 378
+2024/05/19 23:42:24 Generating 7172 numbers for index: 843
+2024/05/19 23:42:24 Generating 7034 numbers for index: 926
+2024/05/19 23:42:24 Generating 16771 numbers for index: 295
+2024/05/19 23:42:24 Generating 16202 numbers for index: 294
+2024/05/19 23:42:24 Generating 22999 numbers for index: 927
+2024/05/19 23:42:24 Generating 18441 numbers for index: 320
+2024/05/19 23:42:24 Generating 45967 numbers for index: 816
+2024/05/19 23:42:24 Generating 11952 numbers for index: 921
+2024/05/19 23:42:24 Generating 39590 numbers for index: 817
+2024/05/19 23:42:24 Generating 35501 numbers for index: 922
+2024/05/19 23:42:24 Generating 29066 numbers for index: 844
+2024/05/19 23:42:24 Generating 19043 numbers for index: 928
+2024/05/19 23:42:24 Generating 23184 numbers for index: 931
+2024/05/19 23:42:24 Generating 30731 numbers for index: 846
+2024/05/19 23:42:24 Generating 2589 numbers for index: 595
+2024/05/19 23:42:24 Generating 16659 numbers for index: 730
+2024/05/19 23:42:24 Generating 7515 numbers for index: 618
+2024/05/19 23:42:24 Generating 42089 numbers for index: 597
+2024/05/19 23:42:24 Generating 49290 numbers for index: 677
+2024/05/19 23:42:24 Generating 32508 numbers for index: 717
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_506.txt for index: 506
+2024/05/19 23:42:24 Generating 22574 numbers for index: 780
+2024/05/19 23:42:24 Generating 26282 numbers for index: 832
+2024/05/19 23:42:24 Generating 30885 numbers for index: 848
+2024/05/19 23:42:24 Generating 12002 numbers for index: 754
+2024/05/19 23:42:24 Generating 24966 numbers for index: 740
+2024/05/19 23:42:24 Generating 30213 numbers for index: 982
+2024/05/19 23:42:24 Generating 38802 numbers for index: 620
+2024/05/19 23:42:24 Generating 31537 numbers for index: 774
+2024/05/19 23:42:24 Generating 16836 numbers for index: 672
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_177.txt for index: 177
+2024/05/19 23:42:24 Generating 24054 numbers for index: 786
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_612.txt for index: 612
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_751.txt for index: 751
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_152.txt for index: 152
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_911.txt for index: 911
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_96.txt for index: 96
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_759.txt for index: 759
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_519.txt for index: 519
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_888.txt for index: 888
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_601.txt for index: 601
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_274.txt for index: 274
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_284.txt for index: 284
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_676.txt for index: 676
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_948.txt for index: 948
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_227.txt for index: 227
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_932.txt for index: 932
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_828.txt for index: 828
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_512.txt for index: 512
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_127.txt for index: 127
+2024/05/19 23:42:24 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_552.txt for index: 552
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_906.txt for index: 906
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_418.txt for index: 418
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_109.txt for index: 109
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_657.txt for index: 657
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_428.txt for index: 428
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_791.txt for index: 791
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_598.txt for index: 598
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_486.txt for index: 486
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_582.txt for index: 582
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_762.txt for index: 762
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_27.txt for index: 27
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_254.txt for index: 254
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_437.txt for index: 437
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_594.txt for index: 594
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_153.txt for index: 153
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_733.txt for index: 733
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_614.txt for index: 614
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_475.txt for index: 475
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_460.txt for index: 460
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_401.txt for index: 401
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_851.txt for index: 851
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_985.txt for index: 985
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_595.txt for index: 595
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_293.txt for index: 293
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_82.txt for index: 82
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_617.txt for index: 617
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_823.txt for index: 823
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_149.txt for index: 149
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_111.txt for index: 111
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_373.txt for index: 373
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_474.txt for index: 474
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_280.txt for index: 280
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_793.txt for index: 793
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_841.txt for index: 841
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_559.txt for index: 559
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_354.txt for index: 354
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_283.txt for index: 283
+2024/05/19 23:42:25 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_121.txt for index: 121
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_491.txt for index: 491
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_536.txt for index: 536
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_193.txt for index: 193
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_744.txt for index: 744
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_8.txt for index: 8
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_647.txt for index: 647
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_757.txt for index: 757
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_859.txt for index: 859
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_837.txt for index: 837
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_287.txt for index: 287
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_286.txt for index: 286
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_105.txt for index: 105
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_628.txt for index: 628
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_133.txt for index: 133
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_256.txt for index: 256
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_315.txt for index: 315
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_849.txt for index: 849
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_43.txt for index: 43
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_77.txt for index: 77
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_777.txt for index: 777
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_670.txt for index: 670
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_596.txt for index: 596
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_14.txt for index: 14
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_884.txt for index: 884
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_114.txt for index: 114
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_165.txt for index: 165
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_950.txt for index: 950
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_562.txt for index: 562
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_239.txt for index: 239
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_942.txt for index: 942
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_739.txt for index: 739
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_875.txt for index: 875
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_74.txt for index: 74
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_13.txt for index: 13
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_383.txt for index: 383
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_869.txt for index: 869
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_215.txt for index: 215
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_853.txt for index: 853
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_787.txt for index: 787
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_738.txt for index: 738
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_815.txt for index: 815
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_669.txt for index: 669
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_624.txt for index: 624
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_551.txt for index: 551
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_688.txt for index: 688
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_566.txt for index: 566
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_158.txt for index: 158
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_180.txt for index: 180
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_880.txt for index: 880
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_311.txt for index: 311
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_388.txt for index: 388
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_430.txt for index: 430
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_5.txt for index: 5
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_548.txt for index: 548
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_203.txt for index: 203
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_19.txt for index: 19
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_396.txt for index: 396
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_623.txt for index: 623
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_567.txt for index: 567
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_698.txt for index: 698
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_764.txt for index: 764
+2024/05/19 23:42:26 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_779.txt for index: 779
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_235.txt for index: 235
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_529.txt for index: 529
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_181.txt for index: 181
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_835.txt for index: 835
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_343.txt for index: 343
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_242.txt for index: 242
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_442.txt for index: 442
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_975.txt for index: 975
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_804.txt for index: 804
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_627.txt for index: 627
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_198.txt for index: 198
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_770.txt for index: 770
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_681.txt for index: 681
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_339.txt for index: 339
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_926.txt for index: 926
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_833.txt for index: 833
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_250.txt for index: 250
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_302.txt for index: 302
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_179.txt for index: 179
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_531.txt for index: 531
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_392.txt for index: 392
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_665.txt for index: 665
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_989.txt for index: 989
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_917.txt for index: 917
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_238.txt for index: 238
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_188.txt for index: 188
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_800.txt for index: 800
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_79.txt for index: 79
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_648.txt for index: 648
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_240.txt for index: 240
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_912.txt for index: 912
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_776.txt for index: 776
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_455.txt for index: 455
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_886.txt for index: 886
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_384.txt for index: 384
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_710.txt for index: 710
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_187.txt for index: 187
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_690.txt for index: 690
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_479.txt for index: 479
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_170.txt for index: 170
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_453.txt for index: 453
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_10.txt for index: 10
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_271.txt for index: 271
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_843.txt for index: 843
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_963.txt for index: 963
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_440.txt for index: 440
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_12.txt for index: 12
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_618.txt for index: 618
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_741.txt for index: 741
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_810.txt for index: 810
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_288.txt for index: 288
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_818.txt for index: 818
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_502.txt for index: 502
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_415.txt for index: 415
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_881.txt for index: 881
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_602.txt for index: 602
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_272.txt for index: 272
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_222.txt for index: 222
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_128.txt for index: 128
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_981.txt for index: 981
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_157.txt for index: 157
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_514.txt for index: 514
+2024/05/19 23:42:27 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_719.txt for index: 719
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_98.txt for index: 98
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_877.txt for index: 877
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_731.txt for index: 731
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_7.txt for index: 7
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_472.txt for index: 472
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_712.txt for index: 712
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_103.txt for index: 103
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_174.txt for index: 174
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_718.txt for index: 718
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_438.txt for index: 438
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_850.txt for index: 850
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_868.txt for index: 868
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_714.txt for index: 714
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_160.txt for index: 160
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_726.txt for index: 726
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_678.txt for index: 678
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_772.txt for index: 772
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_563.txt for index: 563
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_956.txt for index: 956
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_743.txt for index: 743
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_573.txt for index: 573
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_138.txt for index: 138
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_781.txt for index: 781
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_457.txt for index: 457
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_411.txt for index: 411
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_724.txt for index: 724
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_680.txt for index: 680
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_988.txt for index: 988
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_969.txt for index: 969
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_808.txt for index: 808
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_305.txt for index: 305
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_515.txt for index: 515
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_834.txt for index: 834
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_631.txt for index: 631
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_232.txt for index: 232
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_279.txt for index: 279
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_169.txt for index: 169
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_9.txt for index: 9
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_705.txt for index: 705
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_697.txt for index: 697
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_263.txt for index: 263
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_112.txt for index: 112
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_427.txt for index: 427
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_992.txt for index: 992
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_66.txt for index: 66
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_429.txt for index: 429
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_538.txt for index: 538
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_693.txt for index: 693
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_679.txt for index: 679
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_168.txt for index: 168
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_124.txt for index: 124
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_891.txt for index: 891
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_638.txt for index: 638
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_641.txt for index: 641
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_318.txt for index: 318
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_984.txt for index: 984
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_918.txt for index: 918
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_902.txt for index: 902
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_88.txt for index: 88
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_944.txt for index: 944
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_754.txt for index: 754
+2024/05/19 23:42:28 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_204.txt for index: 204
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_216.txt for index: 216
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_716.txt for index: 716
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_921.txt for index: 921
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_887.txt for index: 887
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_465.txt for index: 465
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_448.txt for index: 448
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_819.txt for index: 819
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_568.txt for index: 568
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_404.txt for index: 404
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_340.txt for index: 340
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_178.txt for index: 178
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_908.txt for index: 908
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_752.txt for index: 752
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_852.txt for index: 852
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_268.txt for index: 268
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_947.txt for index: 947
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_802.txt for index: 802
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_446.txt for index: 446
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_206.txt for index: 206
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_967.txt for index: 967
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_394.txt for index: 394
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_662.txt for index: 662
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_915.txt for index: 915
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_345.txt for index: 345
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_914.txt for index: 914
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_441.txt for index: 441
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_575.txt for index: 575
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_69.txt for index: 69
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_782.txt for index: 782
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_904.txt for index: 904
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_370.txt for index: 370
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_838.txt for index: 838
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_223.txt for index: 223
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_896.txt for index: 896
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_971.txt for index: 971
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_652.txt for index: 652
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_553.txt for index: 553
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_501.txt for index: 501
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_378.txt for index: 378
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_214.txt for index: 214
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_336.txt for index: 336
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_635.txt for index: 635
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_230.txt for index: 230
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_407.txt for index: 407
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_517.txt for index: 517
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_312.txt for index: 312
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_539.txt for index: 539
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_41.txt for index: 41
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_564.txt for index: 564
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_424.txt for index: 424
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_99.txt for index: 99
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_910.txt for index: 910
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_484.txt for index: 484
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_997.txt for index: 997
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_261.txt for index: 261
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_924.txt for index: 924
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_248.txt for index: 248
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_73.txt for index: 73
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_507.txt for index: 507
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_119.txt for index: 119
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_858.txt for index: 858
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_464.txt for index: 464
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_350.txt for index: 350
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_22.txt for index: 22
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_26.txt for index: 26
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_867.txt for index: 867
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_935.txt for index: 935
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_463.txt for index: 463
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_101.txt for index: 101
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_600.txt for index: 600
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_86.txt for index: 86
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_64.txt for index: 64
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_683.txt for index: 683
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_425.txt for index: 425
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_323.txt for index: 323
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_255.txt for index: 255
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_572.txt for index: 572
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_672.txt for index: 672
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_730.txt for index: 730
+2024/05/19 23:42:29 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_703.txt for index: 703
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_20.txt for index: 20
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_936.txt for index: 936
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_964.txt for index: 964
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_467.txt for index: 467
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_45.txt for index: 45
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_488.txt for index: 488
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_466.txt for index: 466
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_294.txt for index: 294
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_155.txt for index: 155
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_456.txt for index: 456
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_221.txt for index: 221
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_734.txt for index: 734
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_39.txt for index: 39
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_900.txt for index: 900
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_409.txt for index: 409
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_656.txt for index: 656
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_115.txt for index: 115
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_325.txt for index: 325
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_866.txt for index: 866
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_186.txt for index: 186
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_847.txt for index: 847
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_355.txt for index: 355
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_147.txt for index: 147
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_295.txt for index: 295
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_829.txt for index: 829
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_447.txt for index: 447
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_419.txt for index: 419
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_708.txt for index: 708
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_794.txt for index: 794
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_928.txt for index: 928
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_333.txt for index: 333
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_33.txt for index: 33
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_358.txt for index: 358
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_481.txt for index: 481
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_421.txt for index: 421
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_659.txt for index: 659
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_278.txt for index: 278
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_809.txt for index: 809
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_320.txt for index: 320
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_32.txt for index: 32
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_653.txt for index: 653
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_327.txt for index: 327
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_753.txt for index: 753
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_348.txt for index: 348
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_863.txt for index: 863
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_211.txt for index: 211
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_450.txt for index: 450
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_861.txt for index: 861
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_535.txt for index: 535
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_696.txt for index: 696
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_106.txt for index: 106
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_666.txt for index: 666
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_275.txt for index: 275
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_813.txt for index: 813
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_226.txt for index: 226
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_588.txt for index: 588
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_59.txt for index: 59
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_645.txt for index: 645
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_291.txt for index: 291
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_605.txt for index: 605
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_38.txt for index: 38
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_980.txt for index: 980
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_53.txt for index: 53
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_525.txt for index: 525
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_709.txt for index: 709
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_145.txt for index: 145
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_207.txt for index: 207
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_999.txt for index: 999
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_300.txt for index: 300
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_298.txt for index: 298
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_270.txt for index: 270
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_736.txt for index: 736
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_544.txt for index: 544
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_520.txt for index: 520
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_148.txt for index: 148
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_729.txt for index: 729
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_134.txt for index: 134
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_545.txt for index: 545
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_541.txt for index: 541
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_144.txt for index: 144
+2024/05/19 23:42:30 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_589.txt for index: 589
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_269.txt for index: 269
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_341.txt for index: 341
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_856.txt for index: 856
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_590.txt for index: 590
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_824.txt for index: 824
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_306.txt for index: 306
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_434.txt for index: 434
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_70.txt for index: 70
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_692.txt for index: 692
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_500.txt for index: 500
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_399.txt for index: 399
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_122.txt for index: 122
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_694.txt for index: 694
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_62.txt for index: 62
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_123.txt for index: 123
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_426.txt for index: 426
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_550.txt for index: 550
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_973.txt for index: 973
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_357.txt for index: 357
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_742.txt for index: 742
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_715.txt for index: 715
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_482.txt for index: 482
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_609.txt for index: 609
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_24.txt for index: 24
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_927.txt for index: 927
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_313.txt for index: 313
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_839.txt for index: 839
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_780.txt for index: 780
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_309.txt for index: 309
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_492.txt for index: 492
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_784.txt for index: 784
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_322.txt for index: 322
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_766.txt for index: 766
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_836.txt for index: 836
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_220.txt for index: 220
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_30.txt for index: 30
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_264.txt for index: 264
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_433.txt for index: 433
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_107.txt for index: 107
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_949.txt for index: 949
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_244.txt for index: 244
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_387.txt for index: 387
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_945.txt for index: 945
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_297.txt for index: 297
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_832.txt for index: 832
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_957.txt for index: 957
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_55.txt for index: 55
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_218.txt for index: 218
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_191.txt for index: 191
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_704.txt for index: 704
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_229.txt for index: 229
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_876.txt for index: 876
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_331.txt for index: 331
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_807.txt for index: 807
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_660.txt for index: 660
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_740.txt for index: 740
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_786.txt for index: 786
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_901.txt for index: 901
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_931.txt for index: 931
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_252.txt for index: 252
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_664.txt for index: 664
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_40.txt for index: 40
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_797.txt for index: 797
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_276.txt for index: 276
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_94.txt for index: 94
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_52.txt for index: 52
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_164.txt for index: 164
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_176.txt for index: 176
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_498.txt for index: 498
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_579.txt for index: 579
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_87.txt for index: 87
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_201.txt for index: 201
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_459.txt for index: 459
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_46.txt for index: 46
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_332.txt for index: 332
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_364.txt for index: 364
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_321.txt for index: 321
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_934.txt for index: 934
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_578.txt for index: 578
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_878.txt for index: 878
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_113.txt for index: 113
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_398.txt for index: 398
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_976.txt for index: 976
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_76.txt for index: 76
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_480.txt for index: 480
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_577.txt for index: 577
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_558.txt for index: 558
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_75.txt for index: 75
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_795.txt for index: 795
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_916.txt for index: 916
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_436.txt for index: 436
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_360.txt for index: 360
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_476.txt for index: 476
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_540.txt for index: 540
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_943.txt for index: 943
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_471.txt for index: 471
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_637.txt for index: 637
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_825.txt for index: 825
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_458.txt for index: 458
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_518.txt for index: 518
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_231.txt for index: 231
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_304.txt for index: 304
+2024/05/19 23:42:31 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_584.txt for index: 584
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_952.txt for index: 952
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_326.txt for index: 326
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_166.txt for index: 166
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_192.txt for index: 192
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_889.txt for index: 889
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_234.txt for index: 234
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_349.txt for index: 349
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_761.txt for index: 761
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_674.txt for index: 674
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_845.txt for index: 845
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_717.txt for index: 717
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_37.txt for index: 37
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_745.txt for index: 745
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_413.txt for index: 413
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_377.txt for index: 377
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_131.txt for index: 131
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_299.txt for index: 299
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_803.txt for index: 803
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_253.txt for index: 253
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_462.txt for index: 462
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_995.txt for index: 995
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_675.txt for index: 675
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_402.txt for index: 402
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_723.txt for index: 723
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_435.txt for index: 435
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_951.txt for index: 951
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_805.txt for index: 805
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_801.txt for index: 801
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_930.txt for index: 930
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_100.txt for index: 100
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_367.txt for index: 367
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_42.txt for index: 42
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_569.txt for index: 569
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_451.txt for index: 451
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_328.txt for index: 328
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_701.txt for index: 701
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_523.txt for index: 523
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_228.txt for index: 228
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_338.txt for index: 338
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_257.txt for index: 257
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_844.txt for index: 844
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_629.txt for index: 629
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_650.txt for index: 650
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_879.txt for index: 879
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_542.txt for index: 542
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_986.txt for index: 986
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_210.txt for index: 210
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_439.txt for index: 439
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_655.txt for index: 655
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_380.txt for index: 380
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_574.txt for index: 574
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_848.txt for index: 848
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_691.txt for index: 691
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_654.txt for index: 654
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_616.txt for index: 616
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_259.txt for index: 259
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_374.txt for index: 374
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_873.txt for index: 873
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_528.txt for index: 528
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_65.txt for index: 65
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_783.txt for index: 783
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_510.txt for index: 510
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_31.txt for index: 31
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_996.txt for index: 996
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_583.txt for index: 583
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_241.txt for index: 241
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_883.txt for index: 883
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_811.txt for index: 811
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_470.txt for index: 470
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_212.txt for index: 212
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_974.txt for index: 974
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_580.txt for index: 580
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_854.txt for index: 854
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_412.txt for index: 412
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_750.txt for index: 750
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_646.txt for index: 646
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_860.txt for index: 860
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_699.txt for index: 699
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_21.txt for index: 21
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_885.txt for index: 885
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_929.txt for index: 929
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_570.txt for index: 570
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_982.txt for index: 982
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_846.txt for index: 846
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_632.txt for index: 632
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_473.txt for index: 473
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_634.txt for index: 634
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_894.txt for index: 894
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_93.txt for index: 93
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_622.txt for index: 622
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_205.txt for index: 205
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_118.txt for index: 118
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_449.txt for index: 449
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_116.txt for index: 116
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_477.txt for index: 477
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_208.txt for index: 208
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_50.txt for index: 50
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_732.txt for index: 732
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_195.txt for index: 195
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_954.txt for index: 954
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_236.txt for index: 236
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_397.txt for index: 397
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_366.txt for index: 366
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_940.txt for index: 940
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_814.txt for index: 814
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_987.txt for index: 987
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_337.txt for index: 337
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_246.txt for index: 246
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_855.txt for index: 855
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_35.txt for index: 35
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_842.txt for index: 842
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_151.txt for index: 151
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_310.txt for index: 310
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_640.txt for index: 640
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_369.txt for index: 369
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_593.txt for index: 593
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_775.txt for index: 775
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_610.txt for index: 610
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_626.txt for index: 626
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_685.txt for index: 685
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_495.txt for index: 495
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_774.txt for index: 774
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_420.txt for index: 420
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_532.txt for index: 532
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_344.txt for index: 344
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_765.txt for index: 765
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_509.txt for index: 509
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_822.txt for index: 822
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_126.txt for index: 126
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_95.txt for index: 95
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_285.txt for index: 285
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_651.txt for index: 651
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_831.txt for index: 831
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_527.txt for index: 527
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_120.txt for index: 120
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_763.txt for index: 763
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_61.txt for index: 61
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_968.txt for index: 968
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_224.txt for index: 224
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_661.txt for index: 661
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_403.txt for index: 403
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_414.txt for index: 414
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_758.txt for index: 758
+2024/05/19 23:42:32 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_78.txt for index: 78
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_330.txt for index: 330
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_922.txt for index: 922
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_393.txt for index: 393
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_898.txt for index: 898
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_213.txt for index: 213
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_342.txt for index: 342
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_245.txt for index: 245
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_71.txt for index: 71
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_196.txt for index: 196
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_689.txt for index: 689
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_34.txt for index: 34
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_142.txt for index: 142
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_768.txt for index: 768
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_737.txt for index: 737
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_84.txt for index: 84
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_56.txt for index: 56
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_767.txt for index: 767
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_673.txt for index: 673
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_633.txt for index: 633
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_560.txt for index: 560
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_132.txt for index: 132
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_63.txt for index: 63
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_840.txt for index: 840
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_778.txt for index: 778
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_83.txt for index: 83
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_422.txt for index: 422
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_511.txt for index: 511
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_225.txt for index: 225
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_266.txt for index: 266
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_489.txt for index: 489
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_892.txt for index: 892
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_57.txt for index: 57
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_789.txt for index: 789
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_549.txt for index: 549
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_554.txt for index: 554
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_443.txt for index: 443
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_432.txt for index: 432
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_319.txt for index: 319
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_44.txt for index: 44
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_199.txt for index: 199
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_251.txt for index: 251
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_893.txt for index: 893
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_29.txt for index: 29
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_939.txt for index: 939
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_175.txt for index: 175
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_972.txt for index: 972
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_821.txt for index: 821
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_289.txt for index: 289
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_933.txt for index: 933
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_993.txt for index: 993
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_897.txt for index: 897
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_362.txt for index: 362
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_389.txt for index: 389
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_296.txt for index: 296
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_478.txt for index: 478
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_382.txt for index: 382
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_620.txt for index: 620
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_167.txt for index: 167
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_379.txt for index: 379
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_606.txt for index: 606
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_390.txt for index: 390
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_375.txt for index: 375
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_587.txt for index: 587
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_139.txt for index: 139
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_920.txt for index: 920
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_461.txt for index: 461
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_219.txt for index: 219
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_249.txt for index: 249
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_183.txt for index: 183
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_54.txt for index: 54
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_487.txt for index: 487
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_533.txt for index: 533
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_735.txt for index: 735
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_146.txt for index: 146
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_830.txt for index: 830
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_92.txt for index: 92
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_521.txt for index: 521
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_771.txt for index: 771
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_316.txt for index: 316
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_483.txt for index: 483
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_58.txt for index: 58
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_499.txt for index: 499
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_817.txt for index: 817
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_796.txt for index: 796
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_903.txt for index: 903
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_308.txt for index: 308
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_494.txt for index: 494
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_60.txt for index: 60
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_91.txt for index: 91
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_233.txt for index: 233
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_454.txt for index: 454
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_812.txt for index: 812
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_209.txt for index: 209
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_543.txt for index: 543
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_604.txt for index: 604
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_80.txt for index: 80
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_395.txt for index: 395
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_695.txt for index: 695
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_262.txt for index: 262
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_469.txt for index: 469
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_381.txt for index: 381
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_391.txt for index: 391
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_329.txt for index: 329
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_36.txt for index: 36
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_303.txt for index: 303
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_217.txt for index: 217
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_607.txt for index: 607
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_247.txt for index: 247
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_913.txt for index: 913
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_961.txt for index: 961
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_872.txt for index: 872
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_503.txt for index: 503
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_534.txt for index: 534
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_615.txt for index: 615
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_376.txt for index: 376
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_444.txt for index: 444
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_104.txt for index: 104
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_317.txt for index: 317
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_516.txt for index: 516
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_557.txt for index: 557
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_547.txt for index: 547
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_490.txt for index: 490
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_760.txt for index: 760
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_526.txt for index: 526
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_365.txt for index: 365
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_608.txt for index: 608
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_621.txt for index: 621
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_140.txt for index: 140
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_667.txt for index: 667
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_290.txt for index: 290
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_991.txt for index: 991
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_171.txt for index: 171
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_361.txt for index: 361
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_994.txt for index: 994
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_721.txt for index: 721
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_363.txt for index: 363
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_15.txt for index: 15
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_565.txt for index: 565
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_644.txt for index: 644
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_713.txt for index: 713
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_371.txt for index: 371
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_410.txt for index: 410
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_864.txt for index: 864
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_865.txt for index: 865
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_522.txt for index: 522
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_408.txt for index: 408
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_359.txt for index: 359
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_292.txt for index: 292
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_938.txt for index: 938
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_706.txt for index: 706
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_258.txt for index: 258
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_826.txt for index: 826
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_97.txt for index: 97
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_722.txt for index: 722
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_277.txt for index: 277
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_108.txt for index: 108
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_16.txt for index: 16
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_720.txt for index: 720
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_172.txt for index: 172
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_468.txt for index: 468
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_90.txt for index: 90
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_154.txt for index: 154
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_895.txt for index: 895
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_11.txt for index: 11
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_597.txt for index: 597
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_185.txt for index: 185
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_353.txt for index: 353
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_806.txt for index: 806
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_200.txt for index: 200
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_990.txt for index: 990
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_748.txt for index: 748
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_642.txt for index: 642
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_130.txt for index: 130
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_727.txt for index: 727
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_156.txt for index: 156
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_334.txt for index: 334
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_282.txt for index: 282
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_173.txt for index: 173
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_686.txt for index: 686
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_405.txt for index: 405
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_639.txt for index: 639
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_966.txt for index: 966
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_603.txt for index: 603
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_671.txt for index: 671
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_983.txt for index: 983
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_619.txt for index: 619
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_67.txt for index: 67
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_416.txt for index: 416
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_237.txt for index: 237
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_576.txt for index: 576
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_530.txt for index: 530
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_508.txt for index: 508
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_792.txt for index: 792
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_658.txt for index: 658
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_798.txt for index: 798
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_117.txt for index: 117
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_960.txt for index: 960
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_919.txt for index: 919
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_937.txt for index: 937
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_143.txt for index: 143
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_555.txt for index: 555
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_352.txt for index: 352
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_711.txt for index: 711
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_135.txt for index: 135
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_556.txt for index: 556
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_857.txt for index: 857
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_202.txt for index: 202
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_423.txt for index: 423
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_335.txt for index: 335
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_197.txt for index: 197
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_941.txt for index: 941
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_18.txt for index: 18
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_955.txt for index: 955
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_110.txt for index: 110
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_386.txt for index: 386
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_243.txt for index: 243
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_129.txt for index: 129
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_630.txt for index: 630
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_684.txt for index: 684
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_625.txt for index: 625
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_372.txt for index: 372
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_141.txt for index: 141
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_445.txt for index: 445
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_496.txt for index: 496
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_965.txt for index: 965
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_725.txt for index: 725
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_513.txt for index: 513
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_756.txt for index: 756
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_524.txt for index: 524
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_136.txt for index: 136
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_946.txt for index: 946
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_668.txt for index: 668
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_28.txt for index: 28
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_68.txt for index: 68
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_485.txt for index: 485
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_17.txt for index: 17
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_998.txt for index: 998
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_785.txt for index: 785
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_749.txt for index: 749
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_702.txt for index: 702
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_72.txt for index: 72
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_871.txt for index: 871
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_273.txt for index: 273
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_707.txt for index: 707
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_977.txt for index: 977
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_347.txt for index: 347
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_586.txt for index: 586
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_368.txt for index: 368
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_184.txt for index: 184
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_400.txt for index: 400
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_592.txt for index: 592
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_137.txt for index: 137
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_81.txt for index: 81
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_537.txt for index: 537
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_591.txt for index: 591
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_85.txt for index: 85
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_643.txt for index: 643
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_907.txt for index: 907
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_611.txt for index: 611
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_728.txt for index: 728
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_599.txt for index: 599
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_356.txt for index: 356
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_493.txt for index: 493
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_816.txt for index: 816
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_307.txt for index: 307
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_923.txt for index: 923
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_162.txt for index: 162
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_265.txt for index: 265
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_970.txt for index: 970
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_899.txt for index: 899
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_747.txt for index: 747
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_23.txt for index: 23
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_25.txt for index: 25
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_870.txt for index: 870
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_581.txt for index: 581
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_571.txt for index: 571
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_663.txt for index: 663
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_497.txt for index: 497
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_102.txt for index: 102
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_159.txt for index: 159
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_827.txt for index: 827
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_909.txt for index: 909
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_182.txt for index: 182
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_953.txt for index: 953
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_687.txt for index: 687
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_959.txt for index: 959
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_649.txt for index: 649
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_6.txt for index: 6
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_48.txt for index: 48
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_504.txt for index: 504
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_773.txt for index: 773
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_862.txt for index: 862
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_925.txt for index: 925
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_47.txt for index: 47
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_546.txt for index: 546
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_163.txt for index: 163
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_431.txt for index: 431
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_890.txt for index: 890
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_682.txt for index: 682
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_561.txt for index: 561
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_505.txt for index: 505
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_882.txt for index: 882
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_417.txt for index: 417
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_979.txt for index: 979
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_905.txt for index: 905
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_788.txt for index: 788
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_769.txt for index: 769
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_161.txt for index: 161
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_677.txt for index: 677
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_150.txt for index: 150
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_125.txt for index: 125
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_452.txt for index: 452
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_700.txt for index: 700
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_585.txt for index: 585
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_194.txt for index: 194
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_189.txt for index: 189
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_267.txt for index: 267
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_314.txt for index: 314
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_49.txt for index: 49
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_820.txt for index: 820
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_346.txt for index: 346
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_301.txt for index: 301
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_958.txt for index: 958
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_746.txt for index: 746
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_385.txt for index: 385
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_351.txt for index: 351
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_636.txt for index: 636
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_790.txt for index: 790
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_978.txt for index: 978
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_260.txt for index: 260
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_613.txt for index: 613
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_281.txt for index: 281
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_874.txt for index: 874
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_755.txt for index: 755
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_406.txt for index: 406
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_51.txt for index: 51
+2024/05/19 23:42:33 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_962.txt for index: 962
+2024/05/19 23:42:33 Initial random numbers generated: 25413579
+2024/05/19 23:42:33 ------- Part 2: Mapper intermediate sorter -------
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_5.txt for index: 5
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_5.txt for index: 5
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_53.txt for index: 53
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_53.txt for index: 53
+2024/05/19 23:42:33 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_5.txt for index: 5
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_77.txt for index: 77
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_71.txt for index: 71
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_58.txt for index: 58
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_68.txt for index: 68
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_74.txt for index: 74
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_76.txt for index: 76
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_60.txt for index: 60
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_62.txt for index: 62
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_6.txt for index: 6
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_62.txt for index: 62
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_999.txt for index: 999
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_7.txt for index: 7
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_69.txt for index: 69
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_74.txt for index: 74
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_103.txt for index: 103
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_65.txt for index: 65
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_54.txt for index: 54
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_55.txt for index: 55
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_56.txt for index: 56
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_57.txt for index: 57
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_59.txt for index: 59
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_70.txt for index: 70
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_66.txt for index: 66
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_67.txt for index: 67
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_66.txt for index: 66
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_75.txt for index: 75
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_553.txt for index: 553
+2024/05/19 23:42:33 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_3.txt for index: 3
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_127.txt for index: 127
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_6.txt for index: 6
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_782.txt for index: 782
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_127.txt for index: 127
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_800.txt for index: 800
+2024/05/19 23:42:33 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_127.txt for index: 127
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_456.txt for index: 456
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_510.txt for index: 510
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_528.txt for index: 528
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_783.txt for index: 783
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_284.txt for index: 284
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_303.txt for index: 303
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_490.txt for index: 490
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_304.txt for index: 304
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_272.txt for index: 272
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_588.txt for index: 588
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_284.txt for index: 284
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_423.txt for index: 423
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_855.txt for index: 855
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_335.txt for index: 335
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_244.txt for index: 244
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_366.txt for index: 366
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_336.txt for index: 336
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_367.txt for index: 367
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_337.txt for index: 337
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_368.txt for index: 368
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_338.txt for index: 338
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_369.txt for index: 369
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_339.txt for index: 339
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_370.txt for index: 370
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_371.txt for index: 371
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_372.txt for index: 372
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_373.txt for index: 373
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_387.txt for index: 387
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_374.txt for index: 374
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_388.txt for index: 388
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_777.txt for index: 777
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_375.txt for index: 375
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_402.txt for index: 402
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_389.txt for index: 389
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_376.txt for index: 376
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_390.txt for index: 390
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_377.txt for index: 377
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_391.txt for index: 391
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_378.txt for index: 378
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_392.txt for index: 392
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_379.txt for index: 379
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_393.txt for index: 393
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_380.txt for index: 380
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_394.txt for index: 394
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_381.txt for index: 381
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_395.txt for index: 395
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_382.txt for index: 382
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_396.txt for index: 396
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_383.txt for index: 383
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_397.txt for index: 397
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_384.txt for index: 384
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_398.txt for index: 398
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_399.txt for index: 399
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_400.txt for index: 400
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_427.txt for index: 427
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_401.txt for index: 401
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_428.txt for index: 428
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_403.txt for index: 403
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_772.txt for index: 772
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_404.txt for index: 404
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_405.txt for index: 405
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_429.txt for index: 429
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_406.txt for index: 406
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_773.txt for index: 773
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_407.txt for index: 407
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_430.txt for index: 430
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_408.txt for index: 408
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_431.txt for index: 431
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_409.txt for index: 409
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_774.txt for index: 774
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_410.txt for index: 410
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_775.txt for index: 775
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_411.txt for index: 411
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_776.txt for index: 776
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_412.txt for index: 412
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_432.txt for index: 432
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_413.txt for index: 413
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_433.txt for index: 433
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_414.txt for index: 414
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_778.txt for index: 778
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_415.txt for index: 415
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_434.txt for index: 434
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_416.txt for index: 416
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_779.txt for index: 779
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_417.txt for index: 417
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_447.txt for index: 447
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_418.txt for index: 418
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_419.txt for index: 419
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_435.txt for index: 435
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_804.txt for index: 804
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_420.txt for index: 420
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_780.txt for index: 780
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_269.txt for index: 269
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_436.txt for index: 436
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_745.txt for index: 745
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_421.txt for index: 421
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_781.txt for index: 781
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_422.txt for index: 422
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_459.txt for index: 459
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_272.txt for index: 272
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_333.txt for index: 333
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_477.txt for index: 477
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_995.txt for index: 995
+2024/05/19 23:42:33 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_284.txt for index: 284
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_241.txt for index: 241
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_873.txt for index: 873
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_600.txt for index: 600
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_883.txt for index: 883
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_473.txt for index: 473
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_596.txt for index: 596
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_985.txt for index: 985
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_988.txt for index: 988
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_186.txt for index: 186
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_196.txt for index: 196
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_115.txt for index: 115
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_239.txt for index: 239
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_458.txt for index: 458
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_239.txt for index: 239
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_14.txt for index: 14
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_988.txt for index: 988
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_799.txt for index: 799
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_186.txt for index: 186
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_14.txt for index: 14
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_799.txt for index: 799
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_626.txt for index: 626
+2024/05/19 23:42:33 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_799.txt for index: 799
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_402.txt for index: 402
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_854.txt for index: 854
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_288.txt for index: 288
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_494.txt for index: 494
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_612.txt for index: 612
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_341.txt for index: 341
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_522.txt for index: 522
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_829.txt for index: 829
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_831.txt for index: 831
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_311.txt for index: 311
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_206.txt for index: 206
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_636.txt for index: 636
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_385.txt for index: 385
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_95.txt for index: 95
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_351.txt for index: 351
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_81.txt for index: 81
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_100.txt for index: 100
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_320.txt for index: 320
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_994.txt for index: 994
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_99.txt for index: 99
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_998.txt for index: 998
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_833.txt for index: 833
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_529.txt for index: 529
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_622.txt for index: 622
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_26.txt for index: 26
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_285.txt for index: 285
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_821.txt for index: 821
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_243.txt for index: 243
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_312.txt for index: 312
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_332.txt for index: 332
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_352.txt for index: 352
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_86.txt for index: 86
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_177.txt for index: 177
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_210.txt for index: 210
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_253.txt for index: 253
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_211.txt for index: 211
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_178.txt for index: 178
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_229.txt for index: 229
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_195.txt for index: 195
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_252.txt for index: 252
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_231.txt for index: 231
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_230.txt for index: 230
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_212.txt for index: 212
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_179.txt for index: 179
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_463.txt for index: 463
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_805.txt for index: 805
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_597.txt for index: 597
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_166.txt for index: 166
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_785.txt for index: 785
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_626.txt for index: 626
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_52.txt for index: 52
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_748.txt for index: 748
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_427.txt for index: 427
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_801.txt for index: 801
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_759.txt for index: 759
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_21.txt for index: 21
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_759.txt for index: 759
+2024/05/19 23:42:33 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_759.txt for index: 759
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_29.txt for index: 29
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_28.txt for index: 28
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_300.txt for index: 300
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_302.txt for index: 302
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_301.txt for index: 301
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_48.txt for index: 48
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_82.txt for index: 82
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_32.txt for index: 32
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_970.txt for index: 970
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_543.txt for index: 543
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_965.txt for index: 965
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_35.txt for index: 35
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_45.txt for index: 45
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_478.txt for index: 478
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_878.txt for index: 878
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_458.txt for index: 458
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_619.txt for index: 619
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_175.txt for index: 175
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_113.txt for index: 113
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_72.txt for index: 72
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_41.txt for index: 41
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_294.txt for index: 294
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_42.txt for index: 42
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_98.txt for index: 98
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_923.txt for index: 923
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_713.txt for index: 713
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_242.txt for index: 242
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_44.txt for index: 44
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_93.txt for index: 93
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_587.txt for index: 587
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_643.txt for index: 643
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_79.txt for index: 79
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_84.txt for index: 84
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_621.txt for index: 621
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_46.txt for index: 46
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_287.txt for index: 287
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_456.txt for index: 456
+2024/05/19 23:42:33 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_287.txt for index: 287
+2024/05/19 23:42:33 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_15.txt for index: 15
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_15.txt for index: 15
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_287.txt for index: 287
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_57.txt for index: 57
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_130.txt for index: 130
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_612.txt for index: 612
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_612.txt for index: 612
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_545.txt for index: 545
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_494.txt for index: 494
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_545.txt for index: 545
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_225.txt for index: 225
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_710.txt for index: 710
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_903.txt for index: 903
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_409.txt for index: 409
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_565.txt for index: 565
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_118.txt for index: 118
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_973.txt for index: 973
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_584.txt for index: 584
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_624.txt for index: 624
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_735.txt for index: 735
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_71.txt for index: 71
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_755.txt for index: 755
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_864.txt for index: 864
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_104.txt for index: 104
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_106.txt for index: 106
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_870.txt for index: 870
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_954.txt for index: 954
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_641.txt for index: 641
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_487.txt for index: 487
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_61.txt for index: 61
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_18.txt for index: 18
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_523.txt for index: 523
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_514.txt for index: 514
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_25.txt for index: 25
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_105.txt for index: 105
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_91.txt for index: 91
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_834.txt for index: 834
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_608.txt for index: 608
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_743.txt for index: 743
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_173.txt for index: 173
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_317.txt for index: 317
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_207.txt for index: 207
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_39.txt for index: 39
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_425.txt for index: 425
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_358.txt for index: 358
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_22.txt for index: 22
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_979.txt for index: 979
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_30.txt for index: 30
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_591.txt for index: 591
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_694.txt for index: 694
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_276.txt for index: 276
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_547.txt for index: 547
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_271.txt for index: 271
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_695.txt for index: 695
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_38.txt for index: 38
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_613.txt for index: 613
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_36.txt for index: 36
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_592.txt for index: 592
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_109.txt for index: 109
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_31.txt for index: 31
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_27.txt for index: 27
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_350.txt for index: 350
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_917.txt for index: 917
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_37.txt for index: 37
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_194.txt for index: 194
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_191.txt for index: 191
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_204.txt for index: 204
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_34.txt for index: 34
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_8.txt for index: 8
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_129.txt for index: 129
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_249.txt for index: 249
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_248.txt for index: 248
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_549.txt for index: 549
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_986.txt for index: 986
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_703.txt for index: 703
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_217.txt for index: 217
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_261.txt for index: 261
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_77.txt for index: 77
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_921.txt for index: 921
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_552.txt for index: 552
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_810.txt for index: 810
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_24.txt for index: 24
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_847.txt for index: 847
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_136.txt for index: 136
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_704.txt for index: 704
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_835.txt for index: 835
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_686.txt for index: 686
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_7.txt for index: 7
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_646.txt for index: 646
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_489.txt for index: 489
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_718.txt for index: 718
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_725.txt for index: 725
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_221.txt for index: 221
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_961.txt for index: 961
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_143.txt for index: 143
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_711.txt for index: 711
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_314.txt for index: 314
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_860.txt for index: 860
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_664.txt for index: 664
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_935.txt for index: 935
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_582.txt for index: 582
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_935.txt for index: 935
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_582.txt for index: 582
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_582.txt for index: 582
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_118.txt for index: 118
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_210.txt for index: 210
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_242.txt for index: 242
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_38.txt for index: 38
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_417.txt for index: 417
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_613.txt for index: 613
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_431.txt for index: 431
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_935.txt for index: 935
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_496.txt for index: 496
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_505.txt for index: 505
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_808.txt for index: 808
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_493.txt for index: 493
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_183.txt for index: 183
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_627.txt for index: 627
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_960.txt for index: 960
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_146.txt for index: 146
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_571.txt for index: 571
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_116.txt for index: 116
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_281.txt for index: 281
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_953.txt for index: 953
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_661.txt for index: 661
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_47.txt for index: 47
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_630.txt for index: 630
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_594.txt for index: 594
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_595.txt for index: 595
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_962.txt for index: 962
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_20.txt for index: 20
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_498.txt for index: 498
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_97.txt for index: 97
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_292.txt for index: 292
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_812.txt for index: 812
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_919.txt for index: 919
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_325.txt for index: 325
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_933.txt for index: 933
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_509.txt for index: 509
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_944.txt for index: 944
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_859.txt for index: 859
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_474.txt for index: 474
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_719.txt for index: 719
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_448.txt for index: 448
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_114.txt for index: 114
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_804.txt for index: 804
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_777.txt for index: 777
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_654.txt for index: 654
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_468.txt for index: 468
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_993.txt for index: 993
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_561.txt for index: 561
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_966.txt for index: 966
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_155.txt for index: 155
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_959.txt for index: 959
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_12.txt for index: 12
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_190.txt for index: 190
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_190.txt for index: 190
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_190.txt for index: 190
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_424.txt for index: 424
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_843.txt for index: 843
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_951.txt for index: 951
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_242.txt for index: 242
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_769.txt for index: 769
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_142.txt for index: 142
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_578.txt for index: 578
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_583.txt for index: 583
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_535.txt for index: 535
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_744.txt for index: 744
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_744.txt for index: 744
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_842.txt for index: 842
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_918.txt for index: 918
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_492.txt for index: 492
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_731.txt for index: 731
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_607.txt for index: 607
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_586.txt for index: 586
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_162.txt for index: 162
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_764.txt for index: 764
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_764.txt for index: 764
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_163.txt for index: 163
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_479.txt for index: 479
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_472.txt for index: 472
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_852.txt for index: 852
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_655.txt for index: 655
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_106.txt for index: 106
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_891.txt for index: 891
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_631.txt for index: 631
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_824.txt for index: 824
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_348.txt for index: 348
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_693.txt for index: 693
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_495.txt for index: 495
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_365.txt for index: 365
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_787.txt for index: 787
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_110.txt for index: 110
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_79.txt for index: 79
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_207.txt for index: 207
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_697.txt for index: 697
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_401.txt for index: 401
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_297.txt for index: 297
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_380.txt for index: 380
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_438.txt for index: 438
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_275.txt for index: 275
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_434.txt for index: 434
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_360.txt for index: 360
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_331.txt for index: 331
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_180.txt for index: 180
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_75.txt for index: 75
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_645.txt for index: 645
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_792.txt for index: 792
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_259.txt for index: 259
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_518.txt for index: 518
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_43.txt for index: 43
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_836.txt for index: 836
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_788.txt for index: 788
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_794.txt for index: 794
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_513.txt for index: 513
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_83.txt for index: 83
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_40.txt for index: 40
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_830.txt for index: 830
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_343.txt for index: 343
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_170.txt for index: 170
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_327.txt for index: 327
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_658.txt for index: 658
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_134.txt for index: 134
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_610.txt for index: 610
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_981.txt for index: 981
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_500.txt for index: 500
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_855.txt for index: 855
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_499.txt for index: 499
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_729.txt for index: 729
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_511.txt for index: 511
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_877.txt for index: 877
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_491.txt for index: 491
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_49.txt for index: 49
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_980.txt for index: 980
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_184.txt for index: 184
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_813.txt for index: 813
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_340.txt for index: 340
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_572.txt for index: 572
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_825.txt for index: 825
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_849.txt for index: 849
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_978.txt for index: 978
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_575.txt for index: 575
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_466.txt for index: 466
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_865.txt for index: 865
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_868.txt for index: 868
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_50.txt for index: 50
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_85.txt for index: 85
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_874.txt for index: 874
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_289.txt for index: 289
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_484.txt for index: 484
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_814.txt for index: 814
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_875.txt for index: 875
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_889.txt for index: 889
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_309.txt for index: 309
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_807.txt for index: 807
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_310.txt for index: 310
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_897.txt for index: 897
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_278.txt for index: 278
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_789.txt for index: 789
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_579.txt for index: 579
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_80.txt for index: 80
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_589.txt for index: 589
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_991.txt for index: 991
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_291.txt for index: 291
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_517.txt for index: 517
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_629.txt for index: 629
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_481.txt for index: 481
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_766.txt for index: 766
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_51.txt for index: 51
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_828.txt for index: 828
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_305.txt for index: 305
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_931.txt for index: 931
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_471.txt for index: 471
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_556.txt for index: 556
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_839.txt for index: 839
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_939.txt for index: 939
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_161.txt for index: 161
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_526.txt for index: 526
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_940.txt for index: 940
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_532.txt for index: 532
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_838.txt for index: 838
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_926.txt for index: 926
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_426.txt for index: 426
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_758.txt for index: 758
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_893.txt for index: 893
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_527.txt for index: 527
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_308.txt for index: 308
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_469.txt for index: 469
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_537.txt for index: 537
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_256.txt for index: 256
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_257.txt for index: 257
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_840.txt for index: 840
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_442.txt for index: 442
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_941.txt for index: 941
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_295.txt for index: 295
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_440.txt for index: 440
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_470.txt for index: 470
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_562.txt for index: 562
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_449.txt for index: 449
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_441.txt for index: 441
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_802.txt for index: 802
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_749.txt for index: 749
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_13.txt for index: 13
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_638.txt for index: 638
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_33.txt for index: 33
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_710.txt for index: 710
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_262.txt for index: 262
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_841.txt for index: 841
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_550.txt for index: 550
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_258.txt for index: 258
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_480.txt for index: 480
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_846.txt for index: 846
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_786.txt for index: 786
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_771.txt for index: 771
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_464.txt for index: 464
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_306.txt for index: 306
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_620.txt for index: 620
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_299.txt for index: 299
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_733.txt for index: 733
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_611.txt for index: 611
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_747.txt for index: 747
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_974.txt for index: 974
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_685.txt for index: 685
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_307.txt for index: 307
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_122.txt for index: 122
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_246.txt for index: 246
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_245.txt for index: 245
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_154.txt for index: 154
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_942.txt for index: 942
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_936.txt for index: 936
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_736.txt for index: 736
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_752.txt for index: 752
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_557.txt for index: 557
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_283.txt for index: 283
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_751.txt for index: 751
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_934.txt for index: 934
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_816.txt for index: 816
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_521.txt for index: 521
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_270.txt for index: 270
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_503.txt for index: 503
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_576.txt for index: 576
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_623.txt for index: 623
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_992.txt for index: 992
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_988.txt for index: 988
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_760.txt for index: 760
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_977.txt for index: 977
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_971.txt for index: 971
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_573.txt for index: 573
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_73.txt for index: 73
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_23.txt for index: 23
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_609.txt for index: 609
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_590.txt for index: 590
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_504.txt for index: 504
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_666.txt for index: 666
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_871.txt for index: 871
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_78.txt for index: 78
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_87.txt for index: 87
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_815.txt for index: 815
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_599.txt for index: 599
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_827.txt for index: 827
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_952.txt for index: 952
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_92.txt for index: 92
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_88.txt for index: 88
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_880.txt for index: 880
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_639.txt for index: 639
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_634.txt for index: 634
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_920.txt for index: 920
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_803.txt for index: 803
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_455.txt for index: 455
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_845.txt for index: 845
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_996.txt for index: 996
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_208.txt for index: 208
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_647.txt for index: 647
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_101.txt for index: 101
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_896.txt for index: 896
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_625.txt for index: 625
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_902.txt for index: 902
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_157.txt for index: 157
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_726.txt for index: 726
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_313.txt for index: 313
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_353.txt for index: 353
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_818.txt for index: 818
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_507.txt for index: 507
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_159.txt for index: 159
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_761.txt for index: 761
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_894.txt for index: 894
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_869.txt for index: 869
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_989.txt for index: 989
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_823.txt for index: 823
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_635.txt for index: 635
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_205.txt for index: 205
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_601.txt for index: 601
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_94.txt for index: 94
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_497.txt for index: 497
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_662.txt for index: 662
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_950.txt for index: 950
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_959.txt for index: 959
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_910.txt for index: 910
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_949.txt for index: 949
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_949.txt for index: 949
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_645.txt for index: 645
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_842.txt for index: 842
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_781.txt for index: 781
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_658.txt for index: 658
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_291.txt for index: 291
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_910.txt for index: 910
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_29.txt for index: 29
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_781.txt for index: 781
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_710.txt for index: 710
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_329.txt for index: 329
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_329.txt for index: 329
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_593.txt for index: 593
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_910.txt for index: 910
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_645.txt for index: 645
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_593.txt for index: 593
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_498.txt for index: 498
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_918.txt for index: 918
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_229.txt for index: 229
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_262.txt for index: 262
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_629.txt for index: 629
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_352.txt for index: 352
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_364.txt for index: 364
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_182.txt for index: 182
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_150.txt for index: 150
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_197.txt for index: 197
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_219.txt for index: 219
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_501.txt for index: 501
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_581.txt for index: 581
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_676.txt for index: 676
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_972.txt for index: 972
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_238.txt for index: 238
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_731.txt for index: 731
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_734.txt for index: 734
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_546.txt for index: 546
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_709.txt for index: 709
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_232.txt for index: 232
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_392.txt for index: 392
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_164.txt for index: 164
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_486.txt for index: 486
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_757.txt for index: 757
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_928.txt for index: 928
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_606.txt for index: 606
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_768.txt for index: 768
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_890.txt for index: 890
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_909.txt for index: 909
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_955.txt for index: 955
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_651.txt for index: 651
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_887.txt for index: 887
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_349.txt for index: 349
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_687.txt for index: 687
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_198.txt for index: 198
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_683.txt for index: 683
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_688.txt for index: 688
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_673.txt for index: 673
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_139.txt for index: 139
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_908.txt for index: 908
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_214.txt for index: 214
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_233.txt for index: 233
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_644.txt for index: 644
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_884.txt for index: 884
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_927.txt for index: 927
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_999.txt for index: 999
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_520.txt for index: 520
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_215.txt for index: 215
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_982.txt for index: 982
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_691.txt for index: 691
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_203.txt for index: 203
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_141.txt for index: 141
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_319.txt for index: 319
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_767.txt for index: 767
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_819.txt for index: 819
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_863.txt for index: 863
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_765.txt for index: 765
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_555.txt for index: 555
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_916.txt for index: 916
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_990.txt for index: 990
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_96.txt for index: 96
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_800.txt for index: 800
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_132.txt for index: 132
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_533.txt for index: 533
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_560.txt for index: 560
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_570.txt for index: 570
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_563.txt for index: 563
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_475.txt for index: 475
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_886.txt for index: 886
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_254.txt for index: 254
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_784.txt for index: 784
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_282.txt for index: 282
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_541.txt for index: 541
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_476.txt for index: 476
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_542.txt for index: 542
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_714.txt for index: 714
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_559.txt for index: 559
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_791.txt for index: 791
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_633.txt for index: 633
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_937.txt for index: 937
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_354.txt for index: 354
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_975.txt for index: 975
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_326.txt for index: 326
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_323.txt for index: 323
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_286.txt for index: 286
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_997.txt for index: 997
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_737.txt for index: 737
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_279.txt for index: 279
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_525.txt for index: 525
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_263.txt for index: 263
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_181.txt for index: 181
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_867.txt for index: 867
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_588.txt for index: 588
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_879.txt for index: 879
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_822.txt for index: 822
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_512.txt for index: 512
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_290.txt for index: 290
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_826.txt for index: 826
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_158.txt for index: 158
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_790.txt for index: 790
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_793.txt for index: 793
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_544.txt for index: 544
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_443.txt for index: 443
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_963.txt for index: 963
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_753.txt for index: 753
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_738.txt for index: 738
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_976.txt for index: 976
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_519.txt for index: 519
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_739.txt for index: 739
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_938.txt for index: 938
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_457.txt for index: 457
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_506.txt for index: 506
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_837.txt for index: 837
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_798.txt for index: 798
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_90.txt for index: 90
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_531.txt for index: 531
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_462.txt for index: 462
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_437.txt for index: 437
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_876.txt for index: 876
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_63.txt for index: 63
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_957.txt for index: 957
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_618.txt for index: 618
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_642.txt for index: 642
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_872.txt for index: 872
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_682.txt for index: 682
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_727.txt for index: 727
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_987.txt for index: 987
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_616.txt for index: 616
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_948.txt for index: 948
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_668.txt for index: 668
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_722.txt for index: 722
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_140.txt for index: 140
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_124.txt for index: 124
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_797.txt for index: 797
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_674.txt for index: 674
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_361.txt for index: 361
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_740.txt for index: 740
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_615.txt for index: 615
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_754.txt for index: 754
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_605.txt for index: 605
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_741.txt for index: 741
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_328.txt for index: 328
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_742.txt for index: 742
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_280.txt for index: 280
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_19.txt for index: 19
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_632.txt for index: 632
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_524.txt for index: 524
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_444.txt for index: 444
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_728.txt for index: 728
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_732.txt for index: 732
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_131.txt for index: 131
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_216.txt for index: 216
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_598.txt for index: 598
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_485.txt for index: 485
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_770.txt for index: 770
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_502.txt for index: 502
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_580.txt for index: 580
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_756.txt for index: 756
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_888.txt for index: 888
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_386.txt for index: 386
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_538.txt for index: 538
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_943.txt for index: 943
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_892.txt for index: 892
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_706.txt for index: 706
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_522.txt for index: 522
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_482.txt for index: 482
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_574.txt for index: 574
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_108.txt for index: 108
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_750.txt for index: 750
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_648.txt for index: 648
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_901.txt for index: 901
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_806.txt for index: 806
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_534.txt for index: 534
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_895.txt for index: 895
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_724.txt for index: 724
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_984.txt for index: 984
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_640.txt for index: 640
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_126.txt for index: 126
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_137.txt for index: 137
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_453.txt for index: 453
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_362.txt for index: 362
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_111.txt for index: 111
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_540.txt for index: 540
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_112.txt for index: 112
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_856.txt for index: 856
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_637.txt for index: 637
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_166.txt for index: 166
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_866.txt for index: 866
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_138.txt for index: 138
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_548.txt for index: 548
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_102.txt for index: 102
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_881.txt for index: 881
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_964.txt for index: 964
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_672.txt for index: 672
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_958.txt for index: 958
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_809.txt for index: 809
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_510.txt for index: 510
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_496.txt for index: 496
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_390.txt for index: 390
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_288.txt for index: 288
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_180.txt for index: 180
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_180.txt for index: 180
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_297.txt for index: 297
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_186.txt for index: 186
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_136.txt for index: 136
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_592.txt for index: 592
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_288.txt for index: 288
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_957.txt for index: 957
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_830.txt for index: 830
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_264.txt for index: 264
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_264.txt for index: 264
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_471.txt for index: 471
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_615.txt for index: 615
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_882.txt for index: 882
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_297.txt for index: 297
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_390.txt for index: 390
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_231.txt for index: 231
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_843.txt for index: 843
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_46.txt for index: 46
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_212.txt for index: 212
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_755.txt for index: 755
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_488.txt for index: 488
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_259.txt for index: 259
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_920.txt for index: 920
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_882.txt for index: 882
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_97.txt for index: 97
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_754.txt for index: 754
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_488.txt for index: 488
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_925.txt for index: 925
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_144.txt for index: 144
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_931.txt for index: 931
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_722.txt for index: 722
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_930.txt for index: 930
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_792.txt for index: 792
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_145.txt for index: 145
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_712.txt for index: 712
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_140.txt for index: 140
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_312.txt for index: 312
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_305.txt for index: 305
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_965.txt for index: 965
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_452.txt for index: 452
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_363.txt for index: 363
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_530.txt for index: 530
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_318.txt for index: 318
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_604.txt for index: 604
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_240.txt for index: 240
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_439.txt for index: 439
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_817.txt for index: 817
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_366.txt for index: 366
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_357.txt for index: 357
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_929.txt for index: 929
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_932.txt for index: 932
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_454.txt for index: 454
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_265.txt for index: 265
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_267.txt for index: 267
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_260.txt for index: 260
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_446.txt for index: 446
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_795.txt for index: 795
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_356.txt for index: 356
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_58.txt for index: 58
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_820.txt for index: 820
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_677.txt for index: 677
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_924.txt for index: 924
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_708.txt for index: 708
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_293.txt for index: 293
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_346.txt for index: 346
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_656.txt for index: 656
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_321.txt for index: 321
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_460.txt for index: 460
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_707.txt for index: 707
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_536.txt for index: 536
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_483.txt for index: 483
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_763.txt for index: 763
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_192.txt for index: 192
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_172.txt for index: 172
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_171.txt for index: 171
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_554.txt for index: 554
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_861.txt for index: 861
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_17.txt for index: 17
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_947.txt for index: 947
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_213.txt for index: 213
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_330.txt for index: 330
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_467.txt for index: 467
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_696.txt for index: 696
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_226.txt for index: 226
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_10.txt for index: 10
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_832.txt for index: 832
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_322.txt for index: 322
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_899.txt for index: 899
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_730.txt for index: 730
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_445.txt for index: 445
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_967.txt for index: 967
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_811.txt for index: 811
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_762.txt for index: 762
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_969.txt for index: 969
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_885.txt for index: 885
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_617.txt for index: 617
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_152.txt for index: 152
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_218.txt for index: 218
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_153.txt for index: 153
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_614.txt for index: 614
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_715.txt for index: 715
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_451.txt for index: 451
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_149.txt for index: 149
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_298.txt for index: 298
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_660.txt for index: 660
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_700.txt for index: 700
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_274.txt for index: 274
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_619.txt for index: 619
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_653.txt for index: 653
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_508.txt for index: 508
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_746.txt for index: 746
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_716.txt for index: 716
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_558.txt for index: 558
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_853.txt for index: 853
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_461.txt for index: 461
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_355.txt for index: 355
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_52.txt for index: 52
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_125.txt for index: 125
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_603.txt for index: 603
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_983.txt for index: 983
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_148.txt for index: 148
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_922.txt for index: 922
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_681.txt for index: 681
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_347.txt for index: 347
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_585.txt for index: 585
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_723.txt for index: 723
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_223.txt for index: 223
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_324.txt for index: 324
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_516.txt for index: 516
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_315.txt for index: 315
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_689.txt for index: 689
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_852.txt for index: 852
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_234.txt for index: 234
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_924.txt for index: 924
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_234.txt for index: 234
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_231.txt for index: 231
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_852.txt for index: 852
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_658.txt for index: 658
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_453.txt for index: 453
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_924.txt for index: 924
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_212.txt for index: 212
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_708.txt for index: 708
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_97.txt for index: 97
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_434.txt for index: 434
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_535.txt for index: 535
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_968.txt for index: 968
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_453.txt for index: 453
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_776.txt for index: 776
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_518.txt for index: 518
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_59.txt for index: 59
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_644.txt for index: 644
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_776.txt for index: 776
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_144.txt for index: 144
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_708.txt for index: 708
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_174.txt for index: 174
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_174.txt for index: 174
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_498.txt for index: 498
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_303.txt for index: 303
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_59.txt for index: 59
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_157.txt for index: 157
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_51.txt for index: 51
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_311.txt for index: 311
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_174.txt for index: 174
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_57.txt for index: 57
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_518.txt for index: 518
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_157.txt for index: 157
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_293.txt for index: 293
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_311.txt for index: 311
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_144.txt for index: 144
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_968.txt for index: 968
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_43.txt for index: 43
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_293.txt for index: 293
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_460.txt for index: 460
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_345.txt for index: 345
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_828.txt for index: 828
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_828.txt for index: 828
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_345.txt for index: 345
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_410.txt for index: 410
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_294.txt for index: 294
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_805.txt for index: 805
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_200.txt for index: 200
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_912.txt for index: 912
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_659.txt for index: 659
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_725.txt for index: 725
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_268.txt for index: 268
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_956.txt for index: 956
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_345.txt for index: 345
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_202.txt for index: 202
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_103.txt for index: 103
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_841.txt for index: 841
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_930.txt for index: 930
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_368.txt for index: 368
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_251.txt for index: 251
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_898.txt for index: 898
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_120.txt for index: 120
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_663.txt for index: 663
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_913.txt for index: 913
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_151.txt for index: 151
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_165.txt for index: 165
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_671.txt for index: 671
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_185.txt for index: 185
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_782.txt for index: 782
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_107.txt for index: 107
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_121.txt for index: 121
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_119.txt for index: 119
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_450.txt for index: 450
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_250.txt for index: 250
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_377.txt for index: 377
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_698.txt for index: 698
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_839.txt for index: 839
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_654.txt for index: 654
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_705.txt for index: 705
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_364.txt for index: 364
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_89.txt for index: 89
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_11.txt for index: 11
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_577.txt for index: 577
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_9.txt for index: 9
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_64.txt for index: 64
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_201.txt for index: 201
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_224.txt for index: 224
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_316.txt for index: 316
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_692.txt for index: 692
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_235.txt for index: 235
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_247.txt for index: 247
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_193.txt for index: 193
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_796.txt for index: 796
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_227.txt for index: 227
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_344.txt for index: 344
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_237.txt for index: 237
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_135.txt for index: 135
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_848.txt for index: 848
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_702.txt for index: 702
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_679.txt for index: 679
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_946.txt for index: 946
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_273.txt for index: 273
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_255.txt for index: 255
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_914.txt for index: 914
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_169.txt for index: 169
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_359.txt for index: 359
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_160.txt for index: 160
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_721.txt for index: 721
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_342.txt for index: 342
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_862.txt for index: 862
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_209.txt for index: 209
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_176.txt for index: 176
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_566.txt for index: 566
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_906.txt for index: 906
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_236.txt for index: 236
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_701.txt for index: 701
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_675.txt for index: 675
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_567.txt for index: 567
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_199.txt for index: 199
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_271.txt for index: 271
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_228.txt for index: 228
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_16.txt for index: 16
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_515.txt for index: 515
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_564.txt for index: 564
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_851.txt for index: 851
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_628.txt for index: 628
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_296.txt for index: 296
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_850.txt for index: 850
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_680.txt for index: 680
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_678.txt for index: 678
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_785.txt for index: 785
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_915.txt for index: 915
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_602.txt for index: 602
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_907.txt for index: 907
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_133.txt for index: 133
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_188.txt for index: 188
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_667.txt for index: 667
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_904.txt for index: 904
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_147.txt for index: 147
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_670.txt for index: 670
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_905.txt for index: 905
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_669.txt for index: 669
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_123.txt for index: 123
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_168.txt for index: 168
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_900.txt for index: 900
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_539.txt for index: 539
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_717.txt for index: 717
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_858.txt for index: 858
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_220.txt for index: 220
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_266.txt for index: 266
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_652.txt for index: 652
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_569.txt for index: 569
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_222.txt for index: 222
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_690.txt for index: 690
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_187.txt for index: 187
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_189.txt for index: 189
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_334.txt for index: 334
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_167.txt for index: 167
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_117.txt for index: 117
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_657.txt for index: 657
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_156.txt for index: 156
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_857.txt for index: 857
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_699.txt for index: 699
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_684.txt for index: 684
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_438.txt for index: 438
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_465.txt for index: 465
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_687.txt for index: 687
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_996.txt for index: 996
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_744.txt for index: 744
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_998.txt for index: 998
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_874.txt for index: 874
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_971.txt for index: 971
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_492.txt for index: 492
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_531.txt for index: 531
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_947.txt for index: 947
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_531.txt for index: 531
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_971.txt for index: 971
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_583.txt for index: 583
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_402.txt for index: 402
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_995.txt for index: 995
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_492.txt for index: 492
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_947.txt for index: 947
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_143.txt for index: 143
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_122.txt for index: 122
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_393.txt for index: 393
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_281.txt for index: 281
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_213.txt for index: 213
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_606.txt for index: 606
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_584.txt for index: 584
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_995.txt for index: 995
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_122.txt for index: 122
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_584.txt for index: 584
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_89.txt for index: 89
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_89.txt for index: 89
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_76.txt for index: 76
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_12.txt for index: 12
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_393.txt for index: 393
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_300.txt for index: 300
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_264.txt for index: 264
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_354.txt for index: 354
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_606.txt for index: 606
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_213.txt for index: 213
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_239.txt for index: 239
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_515.txt for index: 515
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_354.txt for index: 354
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_569.txt for index: 569
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_12.txt for index: 12
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_949.txt for index: 949
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_363.txt for index: 363
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_573.txt for index: 573
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_25.txt for index: 25
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_696.txt for index: 696
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_391.txt for index: 391
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_577.txt for index: 577
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_705.txt for index: 705
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_539.txt for index: 539
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_420.txt for index: 420
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_705.txt for index: 705
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_539.txt for index: 539
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_125.txt for index: 125
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_577.txt for index: 577
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_815.txt for index: 815
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_854.txt for index: 854
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_711.txt for index: 711
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_815.txt for index: 815
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_79.txt for index: 79
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_411.txt for index: 411
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_356.txt for index: 356
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_113.txt for index: 113
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_435.txt for index: 435
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_114.txt for index: 114
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_430.txt for index: 430
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_873.txt for index: 873
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_404.txt for index: 404
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_73.txt for index: 73
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_33.txt for index: 33
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_277.txt for index: 277
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_693.txt for index: 693
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_275.txt for index: 275
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_276.txt for index: 276
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_649.txt for index: 649
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_553.txt for index: 553
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_665.txt for index: 665
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_650.txt for index: 650
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_551.txt for index: 551
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_844.txt for index: 844
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_945.txt for index: 945
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_128.txt for index: 128
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_911.txt for index: 911
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_568.txt for index: 568
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_631.txt for index: 631
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_966.txt for index: 966
+2024/05/19 23:42:34 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_720.txt for index: 720
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_142.txt for index: 142
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_10.txt for index: 10
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_881.txt for index: 881
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_253.txt for index: 253
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_10.txt for index: 10
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_700.txt for index: 700
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_881.txt for index: 881
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_347.txt for index: 347
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_706.txt for index: 706
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_148.txt for index: 148
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_126.txt for index: 126
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_260.txt for index: 260
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_148.txt for index: 148
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_253.txt for index: 253
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_208.txt for index: 208
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_161.txt for index: 161
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_126.txt for index: 126
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_706.txt for index: 706
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_792.txt for index: 792
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_338.txt for index: 338
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_347.txt for index: 347
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_581.txt for index: 581
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_663.txt for index: 663
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_913.txt for index: 913
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_322.txt for index: 322
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_102.txt for index: 102
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_700.txt for index: 700
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_725.txt for index: 725
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_690.txt for index: 690
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_208.txt for index: 208
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_690.txt for index: 690
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_322.txt for index: 322
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_338.txt for index: 338
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_424.txt for index: 424
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_849.txt for index: 849
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_707.txt for index: 707
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_849.txt for index: 849
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_191.txt for index: 191
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_913.txt for index: 913
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_424.txt for index: 424
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_30.txt for index: 30
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_832.txt for index: 832
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_741.txt for index: 741
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_162.txt for index: 162
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_350.txt for index: 350
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_102.txt for index: 102
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_170.txt for index: 170
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_478.txt for index: 478
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_893.txt for index: 893
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_191.txt for index: 191
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_654.txt for index: 654
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_494.txt for index: 494
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_455.txt for index: 455
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_481.txt for index: 481
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_903.txt for index: 903
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_19.txt for index: 19
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_719.txt for index: 719
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_491.txt for index: 491
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_448.txt for index: 448
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_766.txt for index: 766
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_205.txt for index: 205
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_418.txt for index: 418
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_970.txt for index: 970
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_736.txt for index: 736
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_263.txt for index: 263
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_195.txt for index: 195
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_928.txt for index: 928
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_291.txt for index: 291
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_532.txt for index: 532
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_99.txt for index: 99
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_652.txt for index: 652
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_315.txt for index: 315
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_55.txt for index: 55
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_211.txt for index: 211
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_67.txt for index: 67
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_528.txt for index: 528
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_163.txt for index: 163
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_753.txt for index: 753
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_867.txt for index: 867
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_867.txt for index: 867
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_788.txt for index: 788
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_257.txt for index: 257
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_593.txt for index: 593
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_753.txt for index: 753
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_916.txt for index: 916
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_755.txt for index: 755
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_240.txt for index: 240
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_240.txt for index: 240
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_379.txt for index: 379
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_266.txt for index: 266
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_435.txt for index: 435
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_594.txt for index: 594
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_163.txt for index: 163
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_770.txt for index: 770
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_257.txt for index: 257
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_919.txt for index: 919
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_417.txt for index: 417
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_251.txt for index: 251
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_770.txt for index: 770
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_707.txt for index: 707
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_444.txt for index: 444
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_158.txt for index: 158
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_847.txt for index: 847
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_594.txt for index: 594
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_158.txt for index: 158
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_731.txt for index: 731
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_671.txt for index: 671
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_350.txt for index: 350
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_659.txt for index: 659
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_922.txt for index: 922
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_511.txt for index: 511
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_404.txt for index: 404
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_812.txt for index: 812
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_826.txt for index: 826
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_94.txt for index: 94
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_112.txt for index: 112
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_916.txt for index: 916
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_616.txt for index: 616
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_379.txt for index: 379
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_112.txt for index: 112
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_528.txt for index: 528
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_469.txt for index: 469
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_266.txt for index: 266
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_788.txt for index: 788
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_327.txt for index: 327
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_932.txt for index: 932
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_932.txt for index: 932
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_63.txt for index: 63
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_556.txt for index: 556
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_811.txt for index: 811
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_847.txt for index: 847
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_958.txt for index: 958
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_490.txt for index: 490
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_355.txt for index: 355
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_450.txt for index: 450
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_868.txt for index: 868
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_360.txt for index: 360
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_251.txt for index: 251
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_780.txt for index: 780
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_868.txt for index: 868
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_355.txt for index: 355
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_919.txt for index: 919
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_450.txt for index: 450
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_407.txt for index: 407
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_780.txt for index: 780
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_360.txt for index: 360
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_193.txt for index: 193
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_372.txt for index: 372
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_484.txt for index: 484
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_619.txt for index: 619
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_193.txt for index: 193
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_407.txt for index: 407
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_134.txt for index: 134
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_907.txt for index: 907
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_146.txt for index: 146
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_993.txt for index: 993
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_863.txt for index: 863
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_286.txt for index: 286
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_444.txt for index: 444
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_726.txt for index: 726
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_219.txt for index: 219
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_773.txt for index: 773
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_655.txt for index: 655
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_343.txt for index: 343
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_783.txt for index: 783
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_421.txt for index: 421
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_310.txt for index: 310
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_809.txt for index: 809
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_967.txt for index: 967
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_702.txt for index: 702
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_458.txt for index: 458
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_809.txt for index: 809
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_387.txt for index: 387
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_783.txt for index: 783
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_967.txt for index: 967
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_430.txt for index: 430
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_762.txt for index: 762
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_750.txt for index: 750
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_91.txt for index: 91
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_179.txt for index: 179
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_762.txt for index: 762
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_642.txt for index: 642
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_875.txt for index: 875
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_684.txt for index: 684
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_179.txt for index: 179
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_875.txt for index: 875
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_173.txt for index: 173
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_369.txt for index: 369
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_387.txt for index: 387
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_873.txt for index: 873
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_607.txt for index: 607
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_248.txt for index: 248
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_499.txt for index: 499
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_620.txt for index: 620
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_649.txt for index: 649
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_229.txt for index: 229
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_86.txt for index: 86
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_131.txt for index: 131
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_248.txt for index: 248
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_96.txt for index: 96
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_96.txt for index: 96
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_167.txt for index: 167
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_403.txt for index: 403
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_423.txt for index: 423
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_146.txt for index: 146
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_86.txt for index: 86
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_2.txt for index: 2
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_131.txt for index: 131
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_298.txt for index: 298
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_472.txt for index: 472
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_19.txt for index: 19
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_167.txt for index: 167
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_472.txt for index: 472
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_233.txt for index: 233
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_409.txt for index: 409
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_862.txt for index: 862
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_592.txt for index: 592
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_634.txt for index: 634
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_175.txt for index: 175
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_298.txt for index: 298
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_484.txt for index: 484
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_951.txt for index: 951
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_241.txt for index: 241
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_485.txt for index: 485
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_426.txt for index: 426
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_650.txt for index: 650
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_621.txt for index: 621
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_371.txt for index: 371
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_800.txt for index: 800
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_177.txt for index: 177
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_561.txt for index: 561
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_73.txt for index: 73
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_110.txt for index: 110
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_21.txt for index: 21
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_432.txt for index: 432
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_565.txt for index: 565
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_348.txt for index: 348
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_973.txt for index: 973
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_455.txt for index: 455
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_69.txt for index: 69
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_155.txt for index: 155
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_367.txt for index: 367
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_44.txt for index: 44
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_94.txt for index: 94
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_948.txt for index: 948
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_948.txt for index: 948
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_745.txt for index: 745
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_129.txt for index: 129
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_807.txt for index: 807
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_202.txt for index: 202
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_679.txt for index: 679
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_598.txt for index: 598
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_509.txt for index: 509
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_121.txt for index: 121
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_399.txt for index: 399
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_811.txt for index: 811
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_381.txt for index: 381
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_871.txt for index: 871
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_255.txt for index: 255
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_121.txt for index: 121
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_403.txt for index: 403
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_391.txt for index: 391
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_337.txt for index: 337
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_958.txt for index: 958
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_255.txt for index: 255
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_399.txt for index: 399
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_629.txt for index: 629
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_691.txt for index: 691
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_963.txt for index: 963
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_963.txt for index: 963
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_173.txt for index: 173
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_137.txt for index: 137
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_381.txt for index: 381
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_974.txt for index: 974
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_337.txt for index: 337
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_878.txt for index: 878
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_822.txt for index: 822
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_991.txt for index: 991
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_856.txt for index: 856
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_512.txt for index: 512
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_512.txt for index: 512
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_330.txt for index: 330
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_69.txt for index: 69
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_469.txt for index: 469
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_234.txt for index: 234
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_217.txt for index: 217
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_162.txt for index: 162
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_290.txt for index: 290
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_83.txt for index: 83
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_68.txt for index: 68
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_118.txt for index: 118
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_300.txt for index: 300
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_508.txt for index: 508
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_959.txt for index: 959
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_848.txt for index: 848
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_320.txt for index: 320
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_53.txt for index: 53
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_896.txt for index: 896
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_685.txt for index: 685
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_603.txt for index: 603
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_884.txt for index: 884
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_206.txt for index: 206
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_529.txt for index: 529
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_454.txt for index: 454
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_912.txt for index: 912
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_628.txt for index: 628
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_9.txt for index: 9
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_689.txt for index: 689
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_703.txt for index: 703
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_176.txt for index: 176
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_542.txt for index: 542
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_145.txt for index: 145
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_747.txt for index: 747
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_362.txt for index: 362
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_962.txt for index: 962
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_412.txt for index: 412
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_543.txt for index: 543
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_698.txt for index: 698
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_394.txt for index: 394
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_861.txt for index: 861
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_865.txt for index: 865
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_555.txt for index: 555
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_135.txt for index: 135
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_341.txt for index: 341
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_823.txt for index: 823
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_978.txt for index: 978
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_423.txt for index: 423
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_999.txt for index: 999
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_276.txt for index: 276
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_647.txt for index: 647
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_695.txt for index: 695
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_626.txt for index: 626
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_921.txt for index: 921
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_294.txt for index: 294
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_766.txt for index: 766
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_233.txt for index: 233
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_48.txt for index: 48
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_598.txt for index: 598
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_813.txt for index: 813
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_24.txt for index: 24
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_361.txt for index: 361
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_465.txt for index: 465
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_588.txt for index: 588
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_655.txt for index: 655
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_664.txt for index: 664
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_78.txt for index: 78
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_466.txt for index: 466
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_340.txt for index: 340
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_161.txt for index: 161
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_70.txt for index: 70
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_522.txt for index: 522
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_286.txt for index: 286
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_249.txt for index: 249
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_917.txt for index: 917
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_33.txt for index: 33
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_372.txt for index: 372
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_673.txt for index: 673
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_259.txt for index: 259
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_728.txt for index: 728
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_839.txt for index: 839
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_646.txt for index: 646
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_77.txt for index: 77
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_831.txt for index: 831
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_384.txt for index: 384
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_507.txt for index: 507
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_511.txt for index: 511
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_973.txt for index: 973
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_207.txt for index: 207
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_81.txt for index: 81
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_327.txt for index: 327
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_643.txt for index: 643
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_580.txt for index: 580
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_975.txt for index: 975
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_615.txt for index: 615
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_373.txt for index: 373
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_214.txt for index: 214
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_60.txt for index: 60
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_84.txt for index: 84
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_93.txt for index: 93
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_422.txt for index: 422
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_945.txt for index: 945
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_306.txt for index: 306
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_639.txt for index: 639
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_923.txt for index: 923
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_578.txt for index: 578
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_562.txt for index: 562
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_697.txt for index: 697
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_41.txt for index: 41
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_72.txt for index: 72
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_607.txt for index: 607
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_890.txt for index: 890
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_339.txt for index: 339
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_662.txt for index: 662
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_116.txt for index: 116
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_14.txt for index: 14
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_203.txt for index: 203
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_622.txt for index: 622
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_850.txt for index: 850
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_13.txt for index: 13
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_544.txt for index: 544
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_540.txt for index: 540
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_283.txt for index: 283
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_13.txt for index: 13
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_576.txt for index: 576
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_283.txt for index: 283
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_850.txt for index: 850
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_697.txt for index: 697
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_822.txt for index: 822
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_793.txt for index: 793
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_168.txt for index: 168
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_793.txt for index: 793
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_694.txt for index: 694
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_203.txt for index: 203
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_832.txt for index: 832
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_544.txt for index: 544
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_100.txt for index: 100
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_119.txt for index: 119
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_672.txt for index: 672
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_168.txt for index: 168
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_50.txt for index: 50
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_119.txt for index: 119
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_171.txt for index: 171
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_672.txt for index: 672
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_576.txt for index: 576
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_806.txt for index: 806
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_100.txt for index: 100
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_336.txt for index: 336
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_50.txt for index: 50
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_719.txt for index: 719
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_676.txt for index: 676
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_487.txt for index: 487
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_676.txt for index: 676
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_326.txt for index: 326
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_304.txt for index: 304
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_432.txt for index: 432
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_661.txt for index: 661
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_819.txt for index: 819
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_554.txt for index: 554
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_816.txt for index: 816
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_336.txt for index: 336
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_644.txt for index: 644
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_819.txt for index: 819
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_170.txt for index: 170
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_377.txt for index: 377
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_741.txt for index: 741
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_554.txt for index: 554
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_806.txt for index: 806
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_101.txt for index: 101
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_735.txt for index: 735
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_401.txt for index: 401
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_996.txt for index: 996
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_794.txt for index: 794
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_548.txt for index: 548
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_323.txt for index: 323
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_17.txt for index: 17
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_46.txt for index: 46
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_562.txt for index: 562
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_548.txt for index: 548
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_659.txt for index: 659
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_794.txt for index: 794
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_323.txt for index: 323
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_756.txt for index: 756
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_110.txt for index: 110
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_299.txt for index: 299
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_520.txt for index: 520
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_871.txt for index: 871
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_696.txt for index: 696
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_754.txt for index: 754
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_115.txt for index: 115
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_627.txt for index: 627
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_152.txt for index: 152
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_152.txt for index: 152
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_303.txt for index: 303
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_29.txt for index: 29
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_214.txt for index: 214
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_113.txt for index: 113
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_638.txt for index: 638
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_348.txt for index: 348
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_908.txt for index: 908
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_519.txt for index: 519
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_519.txt for index: 519
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_656.txt for index: 656
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_666.txt for index: 666
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_872.txt for index: 872
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_520.txt for index: 520
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_154.txt for index: 154
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_638.txt for index: 638
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_495.txt for index: 495
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_908.txt for index: 908
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_245.txt for index: 245
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_894.txt for index: 894
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_656.txt for index: 656
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_666.txt for index: 666
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_683.txt for index: 683
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_805.txt for index: 805
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_711.txt for index: 711
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_683.txt for index: 683
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_894.txt for index: 894
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_27.txt for index: 27
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_27.txt for index: 27
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_245.txt for index: 245
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_331.txt for index: 331
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_39.txt for index: 39
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_514.txt for index: 514
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_476.txt for index: 476
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_285.txt for index: 285
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_675.txt for index: 675
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_258.txt for index: 258
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_177.txt for index: 177
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_843.txt for index: 843
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_280.txt for index: 280
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_282.txt for index: 282
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_280.txt for index: 280
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_631.txt for index: 631
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_944.txt for index: 944
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_62.txt for index: 62
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_496.txt for index: 496
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_900.txt for index: 900
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_944.txt for index: 944
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_440.txt for index: 440
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_228.txt for index: 228
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_440.txt for index: 440
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_900.txt for index: 900
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_184.txt for index: 184
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_172.txt for index: 172
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_358.txt for index: 358
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_808.txt for index: 808
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_879.txt for index: 879
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_236.txt for index: 236
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_578.txt for index: 578
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_808.txt for index: 808
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_143.txt for index: 143
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_837.txt for index: 837
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_596.txt for index: 596
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_648.txt for index: 648
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_226.txt for index: 226
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_269.txt for index: 269
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_837.txt for index: 837
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_943.txt for index: 943
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_560.txt for index: 560
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_648.txt for index: 648
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_596.txt for index: 596
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_228.txt for index: 228
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_22.txt for index: 22
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_914.txt for index: 914
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_128.txt for index: 128
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_721.txt for index: 721
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_810.txt for index: 810
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_551.txt for index: 551
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_550.txt for index: 550
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_309.txt for index: 309
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_964.txt for index: 964
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_493.txt for index: 493
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_551.txt for index: 551
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_310.txt for index: 310
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_443.txt for index: 443
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_810.txt for index: 810
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_563.txt for index: 563
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_16.txt for index: 16
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_261.txt for index: 261
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_682.txt for index: 682
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_90.txt for index: 90
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_505.txt for index: 505
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_563.txt for index: 563
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_497.txt for index: 497
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_261.txt for index: 261
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_951.txt for index: 951
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_443.txt for index: 443
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_72.txt for index: 72
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_90.txt for index: 90
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_302.txt for index: 302
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_570.txt for index: 570
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_366.txt for index: 366
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_302.txt for index: 302
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_761.txt for index: 761
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_674.txt for index: 674
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_497.txt for index: 497
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_358.txt for index: 358
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_668.txt for index: 668
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_743.txt for index: 743
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_221.txt for index: 221
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_189.txt for index: 189
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_329.txt for index: 329
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_748.txt for index: 748
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_221.txt for index: 221
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_790.txt for index: 790
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_479.txt for index: 479
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_678.txt for index: 678
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_798.txt for index: 798
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_918.txt for index: 918
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_854.txt for index: 854
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_791.txt for index: 791
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_479.txt for index: 479
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_183.txt for index: 183
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_515.txt for index: 515
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_149.txt for index: 149
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_713.txt for index: 713
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_475.txt for index: 475
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_467.txt for index: 467
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_149.txt for index: 149
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_475.txt for index: 475
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_791.txt for index: 791
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_678.txt for index: 678
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_553.txt for index: 553
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_888.txt for index: 888
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_888.txt for index: 888
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_449.txt for index: 449
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_941.txt for index: 941
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_836.txt for index: 836
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_41.txt for index: 41
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_76.txt for index: 76
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_972.txt for index: 972
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_939.txt for index: 939
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_254.txt for index: 254
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_254.txt for index: 254
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_47.txt for index: 47
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_782.txt for index: 782
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_74.txt for index: 74
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_820.txt for index: 820
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_483.txt for index: 483
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_891.txt for index: 891
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_523.txt for index: 523
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_125.txt for index: 125
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_891.txt for index: 891
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_92.txt for index: 92
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_545.txt for index: 545
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_915.txt for index: 915
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_238.txt for index: 238
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_441.txt for index: 441
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_845.txt for index: 845
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_635.txt for index: 635
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_238.txt for index: 238
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_886.txt for index: 886
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_915.txt for index: 915
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_956.txt for index: 956
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_764.txt for index: 764
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_997.txt for index: 997
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_65.txt for index: 65
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_301.txt for index: 301
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_441.txt for index: 441
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_483.txt for index: 483
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_712.txt for index: 712
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_64.txt for index: 64
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_886.txt for index: 886
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_802.txt for index: 802
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_635.txt for index: 635
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_552.txt for index: 552
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_926.txt for index: 926
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_452.txt for index: 452
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_571.txt for index: 571
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_869.txt for index: 869
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_37.txt for index: 37
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_463.txt for index: 463
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_397.txt for index: 397
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_61.txt for index: 61
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_34.txt for index: 34
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_732.txt for index: 732
+2024/05/19 23:42:34 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_463.txt for index: 463
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_397.txt for index: 397
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_317.txt for index: 317
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_37.txt for index: 37
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_61.txt for index: 61
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_926.txt for index: 926
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_869.txt for index: 869
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_829.txt for index: 829
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_581.txt for index: 581
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_911.txt for index: 911
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_911.txt for index: 911
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_589.txt for index: 589
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_952.txt for index: 952
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_388.txt for index: 388
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_653.txt for index: 653
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_30.txt for index: 30
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_136.txt for index: 136
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_82.txt for index: 82
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_889.txt for index: 889
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_538.txt for index: 538
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_601.txt for index: 601
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_601.txt for index: 601
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_872.txt for index: 872
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_878.txt for index: 878
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_388.txt for index: 388
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_45.txt for index: 45
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_45.txt for index: 45
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_669.txt for index: 669
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_898.txt for index: 898
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_826.txt for index: 826
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_587.txt for index: 587
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_803.txt for index: 803
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_270.txt for index: 270
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_634.txt for index: 634
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_890.txt for index: 890
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_510.txt for index: 510
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_82.txt for index: 82
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_987.txt for index: 987
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_969.txt for index: 969
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_835.txt for index: 835
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_715.txt for index: 715
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_669.txt for index: 669
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_489.txt for index: 489
+2024/05/19 23:42:34 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_307.txt for index: 307
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_123.txt for index: 123
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_896.txt for index: 896
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_740.txt for index: 740
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_559.txt for index: 559
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_742.txt for index: 742
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_448.txt for index: 448
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_474.txt for index: 474
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_91.txt for index: 91
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_457.txt for index: 457
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_558.txt for index: 558
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_765.txt for index: 765
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_898.txt for index: 898
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_473.txt for index: 473
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_105.txt for index: 105
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_718.txt for index: 718
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_720.txt for index: 720
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_954.txt for index: 954
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_521.txt for index: 521
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_685.txt for index: 685
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_437.txt for index: 437
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_824.txt for index: 824
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_738.txt for index: 738
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_827.txt for index: 827
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_34.txt for index: 34
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_641.txt for index: 641
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_986.txt for index: 986
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_346.txt for index: 346
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_829.txt for index: 829
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_738.txt for index: 738
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_653.txt for index: 653
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_262.txt for index: 262
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_341.txt for index: 341
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_47.txt for index: 47
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_105.txt for index: 105
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_931.txt for index: 931
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_603.txt for index: 603
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_587.txt for index: 587
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_135.txt for index: 135
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_555.txt for index: 555
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_986.txt for index: 986
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_452.txt for index: 452
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_546.txt for index: 546
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_270.txt for index: 270
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_71.txt for index: 71
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_227.txt for index: 227
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_346.txt for index: 346
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_227.txt for index: 227
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_571.txt for index: 571
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_378.txt for index: 378
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_285.txt for index: 285
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_984.txt for index: 984
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_860.txt for index: 860
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_882.txt for index: 882
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_769.txt for index: 769
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_892.txt for index: 892
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_500.txt for index: 500
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_565.txt for index: 565
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_717.txt for index: 717
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_8.txt for index: 8
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_984.txt for index: 984
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_166.txt for index: 166
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_823.txt for index: 823
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_950.txt for index: 950
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_980.txt for index: 980
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_378.txt for index: 378
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_332.txt for index: 332
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_267.txt for index: 267
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_858.txt for index: 858
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_220.txt for index: 220
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_860.txt for index: 860
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_500.txt for index: 500
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_564.txt for index: 564
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_426.txt for index: 426
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_439.txt for index: 439
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_428.txt for index: 428
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_428.txt for index: 428
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_972.txt for index: 972
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_8.txt for index: 8
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_968.txt for index: 968
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_585.txt for index: 585
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_421.txt for index: 421
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_979.txt for index: 979
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_536.txt for index: 536
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_977.txt for index: 977
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_778.txt for index: 778
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_139.txt for index: 139
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_564.txt for index: 564
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_204.txt for index: 204
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_961.txt for index: 961
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_858.txt for index: 858
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_459.txt for index: 459
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_647.txt for index: 647
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_863.txt for index: 863
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_978.txt for index: 978
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_52.txt for index: 52
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_597.txt for index: 597
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_892.txt for index: 892
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_853.txt for index: 853
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_723.txt for index: 723
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_220.txt for index: 220
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_717.txt for index: 717
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_235.txt for index: 235
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_235.txt for index: 235
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_439.txt for index: 439
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_769.txt for index: 769
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_332.txt for index: 332
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_778.txt for index: 778
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_723.txt for index: 723
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_961.txt for index: 961
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_139.txt for index: 139
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_670.txt for index: 670
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_585.txt for index: 585
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_695.txt for index: 695
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_600.txt for index: 600
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_950.txt for index: 950
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_32.txt for index: 32
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_247.txt for index: 247
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_546.txt for index: 546
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_977.txt for index: 977
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_853.txt for index: 853
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_980.txt for index: 980
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_699.txt for index: 699
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_905.txt for index: 905
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_597.txt for index: 597
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_334.txt for index: 334
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_267.txt for index: 267
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_817.txt for index: 817
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_32.txt for index: 32
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_990.txt for index: 990
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_130.txt for index: 130
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_181.txt for index: 181
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_256.txt for index: 256
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_921.txt for index: 921
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_692.txt for index: 692
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_147.txt for index: 147
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_536.txt for index: 536
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_218.txt for index: 218
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_940.txt for index: 940
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_670.txt for index: 670
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_818.txt for index: 818
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_204.txt for index: 204
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_442.txt for index: 442
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_979.txt for index: 979
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_813.txt for index: 813
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_459.txt for index: 459
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_600.txt for index: 600
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_20.txt for index: 20
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_818.txt for index: 818
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_442.txt for index: 442
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_464.txt for index: 464
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_333.txt for index: 333
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_314.txt for index: 314
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_48.txt for index: 48
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_917.txt for index: 917
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_181.txt for index: 181
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_307.txt for index: 307
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_616.txt for index: 616
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_535.txt for index: 535
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_464.txt for index: 464
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_333.txt for index: 333
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_132.txt for index: 132
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_147.txt for index: 147
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_196.txt for index: 196
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_51.txt for index: 51
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_625.txt for index: 625
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_24.txt for index: 24
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_699.txt for index: 699
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_216.txt for index: 216
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_120.txt for index: 120
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_256.txt for index: 256
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_420.txt for index: 420
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_249.txt for index: 249
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_156.txt for index: 156
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_70.txt for index: 70
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_130.txt for index: 130
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_692.txt for index: 692
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_132.txt for index: 132
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_817.txt for index: 817
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_907.txt for index: 907
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_247.txt for index: 247
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_120.txt for index: 120
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_373.txt for index: 373
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_501.txt for index: 501
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_625.txt for index: 625
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_196.txt for index: 196
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_465.txt for index: 465
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_933.txt for index: 933
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_392.txt for index: 392
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_81.txt for index: 81
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_686.txt for index: 686
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_461.txt for index: 461
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_846.txt for index: 846
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_899.txt for index: 899
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_883.txt for index: 883
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_501.txt for index: 501
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_730.txt for index: 730
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_990.txt for index: 990
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_156.txt for index: 156
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_730.txt for index: 730
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_728.txt for index: 728
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_857.txt for index: 857
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_349.txt for index: 349
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_933.txt for index: 933
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_359.txt for index: 359
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_83.txt for index: 83
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_361.txt for index: 361
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_413.txt for index: 413
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_895.txt for index: 895
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_349.txt for index: 349
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_413.txt for index: 413
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_686.txt for index: 686
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_846.txt for index: 846
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_905.txt for index: 905
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_340.txt for index: 340
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_664.txt for index: 664
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_334.txt for index: 334
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_618.txt for index: 618
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_451.txt for index: 451
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_580.txt for index: 580
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_216.txt for index: 216
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_940.txt for index: 940
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_876.txt for index: 876
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_78.txt for index: 78
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_975.txt for index: 975
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_673.txt for index: 673
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_218.txt for index: 218
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_246.txt for index: 246
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_862.txt for index: 862
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_646.txt for index: 646
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_384.txt for index: 384
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_716.txt for index: 716
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_643.txt for index: 643
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_466.txt for index: 466
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_989.txt for index: 989
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_831.txt for index: 831
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_657.txt for index: 657
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_353.txt for index: 353
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_330.txt for index: 330
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_737.txt for index: 737
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_20.txt for index: 20
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_314.txt for index: 314
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_201.txt for index: 201
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_6.txt for index: 6
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_507.txt for index: 507
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_279.txt for index: 279
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_445.txt for index: 445
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_857.txt for index: 857
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_651.txt for index: 651
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_359.txt for index: 359
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_461.txt for index: 461
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_279.txt for index: 279
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_804.txt for index: 804
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_833.txt for index: 833
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_657.txt for index: 657
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_883.txt for index: 883
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_895.txt for index: 895
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_566.txt for index: 566
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_88.txt for index: 88
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_899.txt for index: 899
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_566.txt for index: 566
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_447.txt for index: 447
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_833.txt for index: 833
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_244.txt for index: 244
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_751.txt for index: 751
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_751.txt for index: 751
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_88.txt for index: 88
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_447.txt for index: 447
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_651.txt for index: 651
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_124.txt for index: 124
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_957.txt for index: 957
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_930.txt for index: 930
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_618.txt for index: 618
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_351.txt for index: 351
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_244.txt for index: 244
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_445.txt for index: 445
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_380.txt for index: 380
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_989.txt for index: 989
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_124.txt for index: 124
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_876.txt for index: 876
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_688.txt for index: 688
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_353.txt for index: 353
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_308.txt for index: 308
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_95.txt for index: 95
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_688.txt for index: 688
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_575.txt for index: 575
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_716.txt for index: 716
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_433.txt for index: 433
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_252.txt for index: 252
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_451.txt for index: 451
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_572.txt for index: 572
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_237.txt for index: 237
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_575.txt for index: 575
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_737.txt for index: 737
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_595.txt for index: 595
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_572.txt for index: 572
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_95.txt for index: 95
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_308.txt for index: 308
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_252.txt for index: 252
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_289.txt for index: 289
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_433.txt for index: 433
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_595.txt for index: 595
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_351.txt for index: 351
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_419.txt for index: 419
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_224.txt for index: 224
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_429.txt for index: 429
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_395.txt for index: 395
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_429.txt for index: 429
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_419.txt for index: 419
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_436.txt for index: 436
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_237.txt for index: 237
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_746.txt for index: 746
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_201.txt for index: 201
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_246.txt for index: 246
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_289.txt for index: 289
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_446.txt for index: 446
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_395.txt for index: 395
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_406.txt for index: 406
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_727.txt for index: 727
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_955.txt for index: 955
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_446.txt for index: 446
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_938.txt for index: 938
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_795.txt for index: 795
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_436.txt for index: 436
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_224.txt for index: 224
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_315.txt for index: 315
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_729.txt for index: 729
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_481.txt for index: 481
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_272.txt for index: 272
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_491.txt for index: 491
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_477.txt for index: 477
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_745.txt for index: 745
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_150.txt for index: 150
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_855.txt for index: 855
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_532.txt for index: 532
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_736.txt for index: 736
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_462.txt for index: 462
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_704.txt for index: 704
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_499.txt for index: 499
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_955.txt for index: 955
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_129.txt for index: 129
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_4.txt for index: 4
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_55.txt for index: 55
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_477.txt for index: 477
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_636.txt for index: 636
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_200.txt for index: 200
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_701.txt for index: 701
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_704.txt for index: 704
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_26.txt for index: 26
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_462.txt for index: 462
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_537.txt for index: 537
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_99.txt for index: 99
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_746.txt for index: 746
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_729.txt for index: 729
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_197.txt for index: 197
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_26.txt for index: 26
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_150.txt for index: 150
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_263.txt for index: 263
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_701.txt for index: 701
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_702.txt for index: 702
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_385.txt for index: 385
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_414.txt for index: 414
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_195.txt for index: 195
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_200.txt for index: 200
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_636.txt for index: 636
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_727.txt for index: 727
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_537.txt for index: 537
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_211.txt for index: 211
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_530.txt for index: 530
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_318.txt for index: 318
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_414.txt for index: 414
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_509.txt for index: 509
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_318.txt for index: 318
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_541.txt for index: 541
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_714.txt for index: 714
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_431.txt for index: 431
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_66.txt for index: 66
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_385.txt for index: 385
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_197.txt for index: 197
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_714.txt for index: 714
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_526.txt for index: 526
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_339.txt for index: 339
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_901.txt for index: 901
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_662.txt for index: 662
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_541.txt for index: 541
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_611.txt for index: 611
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_530.txt for index: 530
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_901.txt for index: 901
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_188.txt for index: 188
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_991.txt for index: 991
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_526.txt for index: 526
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_188.txt for index: 188
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_787.txt for index: 787
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_416.txt for index: 416
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_365.txt for index: 365
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_787.txt for index: 787
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_906.txt for index: 906
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_906.txt for index: 906
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_209.txt for index: 209
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_116.txt for index: 116
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_396.txt for index: 396
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_633.txt for index: 633
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_622.txt for index: 622
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_557.txt for index: 557
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_396.txt for index: 396
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_814.txt for index: 814
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_987.txt for index: 987
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_611.txt for index: 611
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_75.txt for index: 75
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_617.txt for index: 617
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_328.txt for index: 328
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_617.txt for index: 617
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_250.txt for index: 250
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_486.txt for index: 486
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_803.txt for index: 803
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_486.txt for index: 486
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_250.txt for index: 250
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_825.txt for index: 825
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_866.txt for index: 866
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_365.txt for index: 365
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_870.txt for index: 870
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_209.txt for index: 209
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_416.txt for index: 416
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_814.txt for index: 814
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_633.txt for index: 633
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_866.txt for index: 866
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_605.txt for index: 605
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_107.txt for index: 107
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_328.txt for index: 328
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_557.txt for index: 557
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_187.txt for index: 187
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_825.txt for index: 825
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_187.txt for index: 187
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_734.txt for index: 734
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_87.txt for index: 87
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_709.txt for index: 709
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_605.txt for index: 605
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_842.txt for index: 842
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_107.txt for index: 107
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_478.txt for index: 478
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_734.txt for index: 734
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_834.txt for index: 834
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_838.txt for index: 838
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_114.txt for index: 114
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_40.txt for index: 40
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_834.txt for index: 834
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_709.txt for index: 709
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_893.txt for index: 893
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_870.txt for index: 870
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_87.txt for index: 87
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_838.txt for index: 838
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_982.txt for index: 982
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_405.txt for index: 405
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_292.txt for index: 292
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_375.txt for index: 375
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_438.txt for index: 438
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_367.txt for index: 367
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_230.txt for index: 230
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_993.txt for index: 993
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_602.txt for index: 602
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_40.txt for index: 40
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_602.txt for index: 602
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_982.txt for index: 982
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_230.txt for index: 230
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_155.txt for index: 155
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_306.txt for index: 306
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_138.txt for index: 138
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_983.txt for index: 983
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_375.txt for index: 375
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_292.txt for index: 292
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_63.txt for index: 63
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_405.txt for index: 405
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_757.txt for index: 757
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_757.txt for index: 757
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_325.txt for index: 325
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_138.txt for index: 138
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_54.txt for index: 54
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_383.txt for index: 383
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_376.txt for index: 376
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_715.txt for index: 715
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_383.txt for index: 383
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_665.txt for index: 665
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_408.txt for index: 408
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_844.txt for index: 844
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_665.txt for index: 665
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_325.txt for index: 325
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_111.txt for index: 111
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_111.txt for index: 111
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_502.txt for index: 502
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_489.txt for index: 489
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_295.txt for index: 295
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_502.txt for index: 502
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_983.txt for index: 983
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_667.txt for index: 667
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_54.txt for index: 54
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_569.txt for index: 569
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_844.txt for index: 844
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_482.txt for index: 482
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_295.txt for index: 295
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_313.txt for index: 313
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_936.txt for index: 936
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_637.txt for index: 637
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_376.txt for index: 376
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_137.txt for index: 137
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_936.txt for index: 936
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_312.txt for index: 312
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_771.txt for index: 771
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_408.txt for index: 408
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_627.txt for index: 627
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_517.txt for index: 517
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_482.txt for index: 482
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_313.txt for index: 313
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_198.txt for index: 198
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_675.txt for index: 675
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_937.txt for index: 937
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_488.txt for index: 488
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_370.txt for index: 370
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_198.txt for index: 198
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_637.txt for index: 637
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_835.txt for index: 835
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_115.txt for index: 115
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_667.txt for index: 667
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_68.txt for index: 68
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_117.txt for index: 117
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_335.txt for index: 335
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_774.txt for index: 774
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_517.txt for index: 517
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_164.txt for index: 164
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_370.txt for index: 370
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_80.txt for index: 80
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_282.txt for index: 282
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_258.txt for index: 258
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_771.txt for index: 771
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_18.txt for index: 18
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_164.txt for index: 164
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_222.txt for index: 222
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_410.txt for index: 410
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_774.txt for index: 774
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_642.txt for index: 642
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_937.txt for index: 937
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_222.txt for index: 222
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_273.txt for index: 273
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_335.txt for index: 335
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_117.txt for index: 117
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_185.txt for index: 185
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_165.txt for index: 165
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_608.txt for index: 608
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_80.txt for index: 80
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_165.txt for index: 165
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_897.txt for index: 897
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_694.txt for index: 694
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_389.txt for index: 389
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_540.txt for index: 540
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_556.txt for index: 556
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_772.txt for index: 772
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_382.txt for index: 382
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_28.txt for index: 28
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_123.txt for index: 123
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_18.txt for index: 18
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_630.txt for index: 630
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_772.txt for index: 772
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_185.txt for index: 185
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_273.txt for index: 273
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_206.txt for index: 206
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_992.txt for index: 992
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_897.txt for index: 897
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_529.txt for index: 529
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_608.txt for index: 608
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_760.txt for index: 760
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_389.txt for index: 389
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_992.txt for index: 992
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_382.txt for index: 382
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_215.txt for index: 215
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_215.txt for index: 215
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_623.txt for index: 623
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_671.txt for index: 671
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_590.txt for index: 590
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_779.txt for index: 779
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_28.txt for index: 28
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_623.txt for index: 623
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_60.txt for index: 60
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_630.txt for index: 630
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_779.txt for index: 779
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_609.txt for index: 609
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_134.txt for index: 134
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_760.txt for index: 760
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_590.txt for index: 590
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_363.txt for index: 363
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_912.txt for index: 912
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_879.txt for index: 879
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_848.txt for index: 848
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_693.txt for index: 693
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_508.txt for index: 508
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_609.txt for index: 609
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_573.txt for index: 573
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_859.txt for index: 859
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_942.txt for index: 942
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_887.txt for index: 887
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_236.txt for index: 236
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_786.txt for index: 786
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_726.txt for index: 726
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_172.txt for index: 172
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_887.txt for index: 887
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_9.txt for index: 9
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_859.txt for index: 859
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_903.txt for index: 903
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_331.txt for index: 331
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_513.txt for index: 513
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_169.txt for index: 169
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_128.txt for index: 128
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_628.txt for index: 628
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_942.txt for index: 942
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_22.txt for index: 22
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_454.txt for index: 454
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_84.txt for index: 84
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_374.txt for index: 374
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_691.txt for index: 691
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_885.txt for index: 885
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_184.txt for index: 184
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_786.txt for index: 786
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_914.txt for index: 914
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_226.txt for index: 226
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_864.txt for index: 864
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_660.txt for index: 660
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_93.txt for index: 93
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_922.txt for index: 922
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_721.txt for index: 721
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_374.txt for index: 374
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_885.txt for index: 885
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_624.txt for index: 624
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_169.txt for index: 169
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_624.txt for index: 624
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_767.txt for index: 767
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_660.txt for index: 660
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_640.txt for index: 640
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_356.txt for index: 356
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_703.txt for index: 703
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_151.txt for index: 151
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_864.txt for index: 864
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_752.txt for index: 752
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_1.txt for index: 1
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_743.txt for index: 743
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_513.txt for index: 513
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_969.txt for index: 969
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_752.txt for index: 752
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_767.txt for index: 767
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_225.txt for index: 225
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_964.txt for index: 964
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_965.txt for index: 965
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_976.txt for index: 976
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_290.txt for index: 290
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_740.txt for index: 740
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_320.txt for index: 320
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_640.txt for index: 640
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_38.txt for index: 38
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_579.txt for index: 579
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_278.txt for index: 278
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_976.txt for index: 976
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_689.txt for index: 689
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_217.txt for index: 217
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_225.txt for index: 225
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_542.txt for index: 542
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_650.txt for index: 650
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_579.txt for index: 579
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_927.txt for index: 927
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_994.txt for index: 994
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_789.txt for index: 789
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_21.txt for index: 21
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_141.txt for index: 141
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_278.txt for index: 278
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_39.txt for index: 39
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_49.txt for index: 49
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_927.txt for index: 927
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_151.txt for index: 151
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_493.txt for index: 493
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_574.txt for index: 574
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_994.txt for index: 994
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_16.txt for index: 16
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_797.txt for index: 797
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_789.txt for index: 789
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_98.txt for index: 98
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_296.txt for index: 296
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_505.txt for index: 505
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_141.txt for index: 141
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_98.txt for index: 98
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_49.txt for index: 49
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_425.txt for index: 425
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_109.txt for index: 109
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_171.txt for index: 171
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_574.txt for index: 574
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_109.txt for index: 109
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_797.txt for index: 797
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_319.txt for index: 319
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_456.txt for index: 456
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_851.txt for index: 851
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_902.txt for index: 902
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_559.txt for index: 559
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_851.txt for index: 851
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_425.txt for index: 425
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_106.txt for index: 106
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_570.txt for index: 570
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_761.txt for index: 761
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_296.txt for index: 296
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_674.txt for index: 674
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_682.txt for index: 682
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_902.txt for index: 902
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_784.txt for index: 784
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_742.txt for index: 742
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_241.txt for index: 241
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_386.txt for index: 386
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_145.txt for index: 145
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_43.txt for index: 43
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_319.txt for index: 319
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_533.txt for index: 533
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_663.txt for index: 663
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_326.txt for index: 326
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_142.txt for index: 142
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_614.txt for index: 614
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_343.txt for index: 343
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_784.txt for index: 784
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_223.txt for index: 223
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_549.txt for index: 549
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_160.txt for index: 160
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_210.txt for index: 210
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_160.txt for index: 160
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_476.txt for index: 476
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_223.txt for index: 223
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_614.txt for index: 614
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_400.txt for index: 400
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_796.txt for index: 796
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_386.txt for index: 386
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_661.txt for index: 661
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_533.txt for index: 533
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_639.txt for index: 639
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_775.txt for index: 775
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_316.txt for index: 316
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_549.txt for index: 549
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_304.txt for index: 304
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_816.txt for index: 816
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_739.txt for index: 739
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_101.txt for index: 101
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_840.txt for index: 840
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_758.txt for index: 758
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_586.txt for index: 586
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_487.txt for index: 487
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_269.txt for index: 269
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_400.txt for index: 400
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_796.txt for index: 796
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_309.txt for index: 309
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_775.txt for index: 775
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_739.txt for index: 739
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_316.txt for index: 316
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_560.txt for index: 560
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_798.txt for index: 798
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_758.txt for index: 758
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_194.txt for index: 194
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_599.txt for index: 599
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_840.txt for index: 840
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_547.txt for index: 547
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_321.txt for index: 321
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_586.txt for index: 586
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_449.txt for index: 449
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_321.txt for index: 321
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_677.txt for index: 677
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_523.txt for index: 523
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_747.txt for index: 747
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_275.txt for index: 275
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_773.txt for index: 773
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_362.txt for index: 362
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_599.txt for index: 599
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_194.txt for index: 194
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_956.txt for index: 956
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_268.txt for index: 268
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_713.txt for index: 713
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_547.txt for index: 547
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_11.txt for index: 11
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_830.txt for index: 830
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_7.txt for index: 7
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_677.txt for index: 677
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_352.txt for index: 352
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_268.txt for index: 268
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_567.txt for index: 567
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_812.txt for index: 812
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_474.txt for index: 474
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_712.txt for index: 712
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_567.txt for index: 567
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_525.txt for index: 525
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_189.txt for index: 189
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_820.txt for index: 820
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_845.txt for index: 845
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_11.txt for index: 11
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_525.txt for index: 525
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_735.txt for index: 735
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_632.txt for index: 632
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_945.txt for index: 945
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_301.txt for index: 301
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_427.txt for index: 427
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_17.txt for index: 17
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_943.txt for index: 943
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_749.txt for index: 749
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_85.txt for index: 85
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_411.txt for index: 411
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_23.txt for index: 23
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_64.txt for index: 64
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_962.txt for index: 962
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_632.txt for index: 632
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_44.txt for index: 44
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_56.txt for index: 56
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_182.txt for index: 182
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_504.txt for index: 504
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_412.txt for index: 412
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_904.txt for index: 904
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_749.txt for index: 749
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_85.txt for index: 85
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_23.txt for index: 23
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_732.txt for index: 732
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_904.txt for index: 904
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_36.txt for index: 36
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_56.txt for index: 56
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_490.txt for index: 490
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_763.txt for index: 763
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_457.txt for index: 457
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_192.txt for index: 192
+2024/05/19 23:42:35 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_317.txt for index: 317
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_281.txt for index: 281
+2024/05/19 23:42:35 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_468.txt for index: 468
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_178.txt for index: 178
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_182.txt for index: 182
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_504.txt for index: 504
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_178.txt for index: 178
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_192.txt for index: 192
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_763.txt for index: 763
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_58.txt for index: 58
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_368.txt for index: 368
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_841.txt for index: 841
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_36.txt for index: 36
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_558.txt for index: 558
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_718.txt for index: 718
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_668.txt for index: 668
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_941.txt for index: 941
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_468.txt for index: 468
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_929.txt for index: 929
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_680.txt for index: 680
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_966.txt for index: 966
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_31.txt for index: 31
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_680.txt for index: 680
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_765.txt for index: 765
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_415.txt for index: 415
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_473.txt for index: 473
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_415.txt for index: 415
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_299.txt for index: 299
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_720.txt for index: 720
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_929.txt for index: 929
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_756.txt for index: 756
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_954.txt for index: 954
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_610.txt for index: 610
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_31.txt for index: 31
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_698.txt for index: 698
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_495.txt for index: 495
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_985.txt for index: 985
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_583.txt for index: 583
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_985.txt for index: 985
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_836.txt for index: 836
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_369.txt for index: 369
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_521.txt for index: 521
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_437.txt for index: 437
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_154.txt for index: 154
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_925.txt for index: 925
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_724.txt for index: 724
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_175.txt for index: 175
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_974.txt for index: 974
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_824.txt for index: 824
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_394.txt for index: 394
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_108.txt for index: 108
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_610.txt for index: 610
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_724.txt for index: 724
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_243.txt for index: 243
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_621.txt for index: 621
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_543.txt for index: 543
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_42.txt for index: 42
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_681.txt for index: 681
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_909.txt for index: 909
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_681.txt for index: 681
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_790.txt for index: 790
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_524.txt for index: 524
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_422.txt for index: 422
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_398.txt for index: 398
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_687.txt for index: 687
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_42.txt for index: 42
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_827.txt for index: 827
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_65.txt for index: 65
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_104.txt for index: 104
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_108.txt for index: 108
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_538.txt for index: 538
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_998.txt for index: 998
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_925.txt for index: 925
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_243.txt for index: 243
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_271.txt for index: 271
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_398.txt for index: 398
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_561.txt for index: 561
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_909.txt for index: 909
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_861.txt for index: 861
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_199.txt for index: 199
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_568.txt for index: 568
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_856.txt for index: 856
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_485.txt for index: 485
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_470.txt for index: 470
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_183.txt for index: 183
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_768.txt for index: 768
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_568.txt for index: 568
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_952.txt for index: 952
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_889.txt for index: 889
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_748.txt for index: 748
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_104.txt for index: 104
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_802.txt for index: 802
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_552.txt for index: 552
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_877.txt for index: 877
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_785.txt for index: 785
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_768.txt for index: 768
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_641.txt for index: 641
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_877.txt for index: 877
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_470.txt for index: 470
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_884.txt for index: 884
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_946.txt for index: 946
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_159.txt for index: 159
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_344.txt for index: 344
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_821.txt for index: 821
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_997.txt for index: 997
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_514.txt for index: 514
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_865.txt for index: 865
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_0.txt for index: 0
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_35.txt for index: 35
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_103.txt for index: 103
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_722.txt for index: 722
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_874.txt for index: 874
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_305.txt for index: 305
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_733.txt for index: 733
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_344.txt for index: 344
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_274.txt for index: 274
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_733.txt for index: 733
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_274.txt for index: 274
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_371.txt for index: 371
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_140.txt for index: 140
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_953.txt for index: 953
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_35.txt for index: 35
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_821.txt for index: 821
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_25.txt for index: 25
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_342.txt for index: 342
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_946.txt for index: 946
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_506.txt for index: 506
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_534.txt for index: 534
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_506.txt for index: 506
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_159.txt for index: 159
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_503.txt for index: 503
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_750.txt for index: 750
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_684.txt for index: 684
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_92.txt for index: 92
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_591.txt for index: 591
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_342.txt for index: 342
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_480.txt for index: 480
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_880.txt for index: 880
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_232.txt for index: 232
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_516.txt for index: 516
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_620.txt for index: 620
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_923.txt for index: 923
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_503.txt for index: 503
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_880.txt for index: 880
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_534.txt for index: 534
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_324.txt for index: 324
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_920.txt for index: 920
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_324.txt for index: 324
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_133.txt for index: 133
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_232.txt for index: 232
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_133.txt for index: 133
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_953.txt for index: 953
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_527.txt for index: 527
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_277.txt for index: 277
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_480.txt for index: 480
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_589.txt for index: 589
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_981.txt for index: 981
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_981.txt for index: 981
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_153.txt for index: 153
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_153.txt for index: 153
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_516.txt for index: 516
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_357.txt for index: 357
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_219.txt for index: 219
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_527.txt for index: 527
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_960.txt for index: 960
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_591.txt for index: 591
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_277.txt for index: 277
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_357.txt for index: 357
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_679.txt for index: 679
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_460.txt for index: 460
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_265.txt for index: 265
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_15.txt for index: 15
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_260.txt for index: 260
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_202.txt for index: 202
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_652.txt for index: 652
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_418.txt for index: 418
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_777.txt for index: 777
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_960.txt for index: 960
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_928.txt for index: 928
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_613.txt for index: 613
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_205.txt for index: 205
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_801.txt for index: 801
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_604.txt for index: 604
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_265.txt for index: 265
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_406.txt for index: 406
+2024/05/19 23:42:36 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_934.txt for index: 934
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_795.txt for index: 795
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_938.txt for index: 938
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_67.txt for index: 67
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_550.txt for index: 550
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_471.txt for index: 471
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_807.txt for index: 807
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_801.txt for index: 801
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_649.txt for index: 649
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_970.txt for index: 970
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_176.txt for index: 176
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_934.txt for index: 934
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_467.txt for index: 467
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_604.txt for index: 604
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_524.txt for index: 524
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_364.txt for index: 364
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_939.txt for index: 939
+2024/05/19 23:42:36 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_199.txt for index: 199
+2024/05/19 23:42:37 ------- Part 3: Reducer final sorter -------
+2024/05/19 23:42:37 Initializing the cursor for all the intermediate sorted files
+[147461373257200 684967988191320 120695447888267 257888223014655 159536828371339 718184553881103 1544382216272325 176021779858374 1082729292598022 54298509506099 4032645520099954 47648286525624 487484471232631 4306927539633069 515901265016193 133826148625051 220289328602671 808476345297211 348075434089055 1019082870818636 67289641703519 594616466517683 145135655272268 59272828937743 117481111106350 705980227478423 334758958938910 4281846254839241 227362584360981 158132524667749 1005481582071648 329524739234984 372787338760053 339363568946353 348339282571991 58578263402565 124756686596834 83470816615139 830298314951583 522519273771180 1090722477726580 291023294106064 398229882342886 8611470898921869 700938175956384 478239935160442 74849019493682 67115406465174 393129808696732 159503224330400 183445560465314 491248951158794 1283432415462994 181883867210384 620125370367013 354467411796811 183604077282880 52593965759020 24114112002140 815702909000684 222487695716873 219501700183123 72823877773556 170713696352019 594686857821180 843223720308180 4570715951822217 159764737914044 1091173349680229 2927647831956072 218662687955095 657663460409860 157977332615293 578326523241491 435412682651017 69305693813242 33594428512102 941150760686671 96365114344822 1092058418860379 386370051939498 263505547368939 9102207451138888 408198698164580 128490618019727 6718587131148 378076280968508 133653382175275 162908917123277 16901511331121692 49589490899132 422571512094125 426755931528368 301214855259391 259866172649882 366534356331428 64601421175120045 122598094719153 2531999436847270 505218467060398 7194809117911 1052762086380202 79008864885619 585963288716292 211603585614958 1467838258946565 254901826986267 1297259339644935 141619320697285 5556741474204134 55899278151052 4539284224929594 632892391981661 179865845031460 1448170324223668 128614444654099 85428264391429 34919357038812 37982659525890 583787806675952 288029040906307 2167175596396632 506199653214405 913398326822108 959297228230373 67818109668104 458023556276983 24713281755180936 135710702820421 788782631488693 84126306918966 384471373082683 202877966445613 7503734410562776 171999646571707 314143479437 67329166428773 126155157322213 405262880921579 17672646772908 617469398298229 85976021829927 797569364997356 20532999327237 111223191862160 67430026711448 75397410545894 338676192282833 236027337988835 5400336933852816 543803952636432 164402058556312 22685478663207133 376909222042462 36002015432918 169283229192766 300252200343743 369272723770401 542151401613420 35356446931939 934299069838069 84905555817379 495185467606443 291172248595349 137756428865962 520351259657714 40224712505145 52893851601723 58524194959783 509550887434244 126137421985386 356238526877885 674708974417182 212848690528221 673841199975776 328888596958307 377864072664781 20480374769126883 542664699828559 2844427645748338 1652811631814374 596361892106348 141523600070924 61134416498813 23472840478042 192618104970398 31100773070246 217049818775062 2224142907621280 132314355217137 1357733731480898775 936843971989044 100504452572582 175887592533926 108328471083634 513865542456461 111591594580289 442709700752929 727969020061395 139012166933302 126583539464859 1166312954436454 132565290190322 412237252958430 180244066665623 452375363298460 416179432171655 184495702884909 356110352192819 676863451801336 353159159608909 390347172158145 134890126419849 325048022066430 1043371262035872 661960156982300 427195641805900 105786030534756 281882183826249 1300901888963494 2130035761207 640732759600009 2401920464031715 136283441732470 191814113410742 191261621357118 1385870452076920 32304716911252534 567693660499299 141497633711830 615135048493353 334963714050881 766089999964613 128000837975246 80779375543586 6524717621790656 380924397735930 208659202193669 112793041117570 786079724866454 615479840173325 26805279504781 2435553736227226 48000057784456 224515859785333 208872809516071 126242207807224 123996000083348 52886715401850 533164242234196 499323359104335 606192290425823 199021077039838 601256827774291 14346323278928502 20562302603157 5740686115097668 170295571952097 351095716788363 241100469177810 367626418122529 455344009835549 54963152398460 57919525621672 89998168449002 180138195746977 596063896445212 630131347335678 517505540796980 29144405232802 142819640142409 1524189756486319 1410743734826234 470244856595891 2014770856007449 90584832110003 693229731970585 79919768955238 349225529604907 646712442139700 12012525906147320 787903704544297 199257855488700 2748629263717629 1783332739320202 122794832091193 2902369088631154 6192794438147178 2952555350533277 127445268748967 838177818237675 893912573850219 231193325478166 4780828113338026 282725302601540 509024510076055 202537557788916 487806423683311 193690726610777 115873774259163 443456151832074 390197422904846 1400656200896884 63504136307177 124236948247498 262755028914197 317761119506291 40743362691173 288712185599034 711308251789066 195324580242333 47172483742264 789601433415845 106072035962082 8009950114162 27112323408356 344249929698631 931933286501106 471016929565147 328521404052135 33628874738894 1209165838543817 645194080085517 1022401081667343 23810053123259079 361739476959506 174007974276322 85348234848669 148702573044445 124815265472711 321595315050056 9141712963463 715348346639233 1747604864878751 394922959426699 121463488142174 357082420548699 536579628651403 879394743402480 753856128810468 81387929943054 57886872673796 464806287518902 60135251567379 142596140732274 404233705407036 47573899724674 169907860217545 972579338810897 165915565868350 189219814657998 109435854338677 241477630366455 162128811431274 1165804912565921 358335779419000 225497401085013 640792479842522 1755431957015086 94754330840610 444854050786951 188405810762637 2072264433455712 226175792829333 228771471444399 406748568431716 479191310477343 253298645851730 107248274333417 31837017236616 731347627172303 425614999813383 76682292696596 11238409528283253 116346299709212 50129471778926 15470559957687 59592646971802 195860029985865 6501536093472 17934811419714 385227541321838 140843341448850 393277315326942 4901958603409550 3808863218840 153636988550279 1754111479735780 281836244582509 212887314273736 400853500059455 202574166229042 690164035711636 147998762102843 1225847175342954 281164671378353 802629725732352 461059636784387 219334498329111 39654912859089 388370897051158 2900927998327388 298493209988863 1338976003381 1442968450882469 1142822725617392 432587420873959 103876986493244 264268459781437 949757492177531 243572740757366 201085476470821 493477675624353 384170879177457 762159063801750 786187656362654 247208829699689 957227452782 4999712638874191 718068429866593 622721888396694 1137787096604223 273939746155765 169346294530552 652683904888739 873296980642357 101589325373123 787096325698270 3649253399801413 163570748061045 4363036143933330 63534847490042 200839655752218 653566613477594 329111560326897 549655435273854 89146272834197 20772528751264251 877840021193338 949009627929536 1311290207773639 23344695033132 2878329013159177 49113707502979 309120892231495 535694647070503 1411360223028536 69426943464738 575112504163092 16847667781529 253134511871081 35032113921668 156583621701504 552913251864003 338897585377709 591558573808357 438153945676000 643944795645770 307323640571697 76628825854473 328460092591124 547643522908914 179845506781452 856028909518535 1112912121386944 804636332569268 943961094486160 1433259610591635 220644040027658 125967796116403 37370547257292 102593851554956 766478408621836 314075705006814 3301760188038691 1619311321574776 406935866591502 79409861488570 205214013511164 1952441899085683 104570999370205 234454615478509 44405167294590 396858032718465 993874185322062 87271036136396 2092709960245489 279968205907949 235204199236938 131437443421538 152725309174608 1725907270440178 26263290671385 251560132231260 26071932684064 77352692787407 370016036148840 564730933471290 72619970092151 5259349789760 1994313930542047 197202153905520 1083663037764346 145087892278978 57834249374099 36486756145852 160058292101739734 12979170359835 304749267633226 138637690347980 874713161753724 40626163833556 1394705071373953 161740886539886 15615684905655 1046831984028900 288610626970934 848043497381352 366633620038439 15475237760538147 162887592682688 398883919475714 205520712796158 230864402875974 337813847987999 246535610794133 316633605023041 390147311549476 281871799492524 1894305193915 142589793675624 1531291784061815 26676383931899 60368010791897 11707236643637 91313674141399 31064867599291 71777815691 94594546583776 660310979390714 149352834079224 472770175744458 800422532553053 76169990269868 408004422429457 269759400358938 211977617171121 1200875012172923 1256311712457918 369771899204979 437945315689837 10611270316066 5239030732944366 621719972515418 128810317807952 163301963909047 7292077972758 499901243959546 659375006982323 2850202108168726 173943953360792 92365035071144 1118678362480078 1390348419362933 691339282496478 10105857999212 1688058181977243 2334672776525748 553663572373064 54675183412637 201104287676140 517955080771280 45019538126464 803598055639748 183691552707479 352915366985441 1239843233666055 237970084117509 519104199442446 353135951171788 97274648899270 123403720719829 14591851086024328 31560360944668 114650020894301 275747189982284 374486534467110 571415087622103 807978549452860 507289705544631 112174532753963 6719506049636 218193823514386 104573201881247 709162699377607 5589235347847356 2235433623718340 128621743654327 8756617055005963 389281062084509 318862127974535 3664445829962595 239571881468785 995554830877481 482397143743662 470053723745729 53820086901072 263203868659592 329089424746154 100236574404036 58681054715833 126641603112627 137995594722917547 333213134495766 4512523022285797 999120442319 48639654461706 11918321764058095 1085519788387827 440639604608108 106986988763847 568959762611974 88248583853659 1725488485906360 59904883972506 132310464951222 30829622979999 22736438862725 2240630830391086 355361277282393 377564545186165 647035011448812 2970486778069 15830365156574 644726143102031 43243402640076 165698949943783 58307907699726 238635666118607 432800285024079 23956000611174 26951199787191 138021760684241 268257123646789 17783280690376 945735514941930 220333130853163 3267298311809311 649776775821355 12738382875368 107165820396511 72013982868147 262671358285600 508424383291060 6189101232045 716351325775491 516168366627928 4774921827616513 4536003245874 658867158307787 27300853055577 100124935484807 930688939005975 221626424562469 74325501364581 553386633945235 110346032876570 117598815440796 148203589861701 287860195158476 429985504780890 666444868681748 1009968366883397 80445076844064 84998025192782 499560110655771 10318483308984400 62362256307698 445103694116685 1114640382380572 1301198352501465 632896673807461 11423790884591 43336503450364 58588502902995 1538821024921121 112128817484034 43729309519831 631293428780442 239835156412835 1896386294642345 567826267578218 231490355895859 1141363767225603 29031743144109 487779363837071 201018993869630 127462952382251 390200898245508 348531770966565 144217401611911 1142030923492367 119712908048196 396007809726995 1702020766415330 48866693506334 244067086932692 45923776868944 9194700342672 447238904430076 1129367081335138 132042356639018 822501577827035 136126150974083 117165445728785 97296990414354 2389022914811714 824254862812060 1511301297718443 625660033267436 44804959223591 634327865157 70931754723516 778038929996880 549396451265625 404468659762274 1730368212916368 331530586643144 731604333450096 32373554996933 48578952224631 2274506338812600 78926482498720 3238284411888264 6220316538286 641998041922848 218762926874858 238366177421784 460610754870028 151271530432 621649949850986 101978606805738 11215962752423 1522525297029474 797365689800393 157750720439594 755069194149956 420257624919838 343294822735077 137619149894501 548415321393144 193142923335517141 683908235523754 478076225033825 2704901719516364 299754480802347 104140401280120 7168550702640085 565646611337148 20979852152404349 182957941211053 21399625147831 9209778704244539 302330627821712 1139342386003065 5185953245834 28503323634298 256313290159889 315255565572418 49660704974021 645095296601597 183184927521957 2745189710990573 150665657458939 380015730505044 341249404029108 1699537578401215 215386051665588 544462052423985 2498703299005232 359215860785196 869132958292693 1185808915127158 226816237502365 15233748706758 384134876545920 855791777603726 2234778759617329 19409562874255 26439717894047 312814840633186 1583643538923761 91924979591230 2090333362657533 648640153373348 354987158465917 3563441712165 499841670023083 422255253244165 21591552377042653 2926953366956707 249347281395437 1759745037934235 232587269558093 3006684341531800 60749100908839 182928538501945 448082262797818 171275840929923 623919399840582 395943520288896 146907369152319 117651461724112 280179506537330 444816423364998 1281048008539343 93484650574200 183992104077848 124967553439084 421083753702815 112223250880851 2265177849549 300843368622765 2122076455803525 850724128211436 227803897191613 540678981078409 394987494454468 10758273090767674 43737480652970 1059505818301758 504133581425484 498761769484911 2197139103431414 996603652828286 97492915752603 501099953616533 664644306930899 213557485278149 202516868505724 29473723062981 1908588895106340 2937072267383 998220372066897 238929363453085 296168565903755 16964977418947 138276685652983 125256068946030 2057397762747744 1250716273474453 3442885753199954 1191704640908251 992354873492812 208973560325676 48067648546712 42773446600327 289546908135022 1459842883227478 1198472338006538 393062695368927 191225575567212 140226421920951 240554661380847 56440813796866 552617433107307 1082918132044192 103064162039906 384487828871269 2651775302328297 59230702059928 287242838327107 11217644799533 91537059609001 410311146653486 4398112125842874 1255261648322550 414726220555508 511306289073110 179274916333831 214272650520041 3215642264307026 186884712895952 565439858875511 1038499874604881 188191692996323 900189342091838 580826875040540 42402469275621841 18177837660594 342668792230648 1743713419407052 159926640401799 298905670362935 66352909429682 83982239852684 144173184850493 472321217905366 386845758923355 146800598201609 202174580445500 1564384074912826 39060922481075 6019154063770 444180736362578 58099205353588 2766373434018265 145529700510090 18338022309663 334870582008055 544353899853740 34427482889299057 1696778535661698 56389067275823 221128475433557 264603827962116 646512380430079 1268243310043232 41726658653815 9845331512476 175068768213885 2916064349919339 274319763162497 279847366188403 42402197224132 141823293333443 603702460762732 399992511592194 276845928882473 321203807202371 316407285482760 837368170837681 4725854714673872 334813115480067 598567764818914 1035180004790619 247123400105721 87678081978174 455288330419290 108836824381806 867285351323 29665981448051 3043378354564687 210860528155487 2047379667592591 340342188285836 100613661163534 55457627140777 5568518959921023 148447812959858 484206759162193 196892930179708 449859046680147 156318087884469 15974874879120 17313645065641 6330925581697 77367935797401 51100767772109 141321163831797 97078269020343 36860001140876 37294996407842 1178352366443587 130312323170937 229985108220857 250053144982639 695389916928744 367338243019406 386080018019763 167297756614392 896978174994223 92534341109675 139680412111095 61535673401658 1884247949318800 491273912546841 168520573350872 25914596020366 66679307214658 123518586644718 518307899647628 374926639624417 369921243553110 1531396106099283 4189494859206615 198930351809209 255335360262996 356714690379170 3707820803358297 82524179924375 131897906759502 1837179924193088 104659121837038 29056369028925 113960449088399 59551707775679 724403482624202 100121246938327 157957568660078]
+2024/05/19 23:42:38 Initiating the streaming merge sort operation on all the opened file
+2024/05/20 00:12:34 ------- Completed -------
+Execution started at:  2024-05-19T23:42:23+05:30
+Execution ended at:  2024-05-20T00:12:34+05:30
+Execution duration:  30m10.8059188s
+Initial random numbers generated:  25413579
+Total entries at final sorted file:  25413579

--- a/mapper_reducer_sorter_problem/output_medium.txt
+++ b/mapper_reducer_sorter_problem/output_medium.txt
@@ -1,0 +1,612 @@
+2024/05/19 23:34:58 ------- Part 1: Generating random numbers -------
+2024/05/19 23:34:58 Initiating random data generation for index: 0
+2024/05/19 23:34:58 Generating 1142 numbers for index: 0
+2024/05/19 23:34:58 Initiating random data generation for index: 2
+2024/05/19 23:34:58 Generating 5206 numbers for index: 2
+2024/05/19 23:34:58 Initiating random data generation for index: 1
+2024/05/19 23:34:58 Generating 43 numbers for index: 1
+2024/05/19 23:34:58 Initiating random data generation for index: 20
+2024/05/19 23:34:58 Initiating random data generation for index: 29
+2024/05/19 23:34:58 Initiating random data generation for index: 12
+2024/05/19 23:34:58 Generating 4921 numbers for index: 12
+2024/05/19 23:34:58 Initiating random data generation for index: 30
+2024/05/19 23:34:58 Generating 286 numbers for index: 30
+2024/05/19 23:34:58 Initiating random data generation for index: 17
+2024/05/19 23:34:58 Generating 5975 numbers for index: 17
+2024/05/19 23:34:58 Initiating random data generation for index: 18
+2024/05/19 23:34:58 Generating 96 numbers for index: 18
+2024/05/19 23:34:58 Initiating random data generation for index: 19
+2024/05/19 23:34:58 Generating 8320 numbers for index: 19
+2024/05/19 23:34:58 Initiating random data generation for index: 14
+2024/05/19 23:34:58 Initiating random data generation for index: 15
+2024/05/19 23:34:58 Initiating random data generation for index: 45
+2024/05/19 23:34:58 Initiating random data generation for index: 51
+2024/05/19 23:34:58 Initiating random data generation for index: 52
+2024/05/19 23:34:58 Initiating random data generation for index: 58
+2024/05/19 23:34:58 Initiating random data generation for index: 67
+2024/05/19 23:34:58 Generating 1572 numbers for index: 67
+2024/05/19 23:34:58 Initiating random data generation for index: 70
+2024/05/19 23:34:58 Generating 7159 numbers for index: 70
+2024/05/19 23:34:58 Initiating random data generation for index: 21
+2024/05/19 23:34:58 Generating 9758 numbers for index: 21
+2024/05/19 23:34:58 Initiating random data generation for index: 73
+2024/05/19 23:34:58 Initiating random data generation for index: 75
+2024/05/19 23:34:58 Initiating random data generation for index: 80
+2024/05/19 23:34:58 Initiating random data generation for index: 81
+2024/05/19 23:34:58 Generating 9803 numbers for index: 81
+2024/05/19 23:34:58 Initiating random data generation for index: 85
+2024/05/19 23:34:58 Initiating random data generation for index: 32
+2024/05/19 23:34:58 Initiating random data generation for index: 89
+2024/05/19 23:34:58 Generating 6368 numbers for index: 89
+2024/05/19 23:34:58 Generating 4294 numbers for index: 45
+2024/05/19 23:34:58 Initiating random data generation for index: 92
+2024/05/19 23:34:58 Generating 7045 numbers for index: 92
+2024/05/19 23:34:58 Initiating random data generation for index: 94
+2024/05/19 23:34:58 Initiating random data generation for index: 97
+2024/05/19 23:34:58 Initiating random data generation for index: 99
+2024/05/19 23:34:58 Generating 1885 numbers for index: 99
+2024/05/19 23:34:58 Generating 5252 numbers for index: 15
+2024/05/19 23:34:58 Initiating random data generation for index: 95
+2024/05/19 23:34:58 Generating 3342 numbers for index: 95
+2024/05/19 23:34:58 Initiating random data generation for index: 22
+2024/05/19 23:34:58 Generating 8868 numbers for index: 22
+2024/05/19 23:34:58 Initiating random data generation for index: 23
+2024/05/19 23:34:58 Generating 5963 numbers for index: 23
+2024/05/19 23:34:58 Initiating random data generation for index: 24
+2024/05/19 23:34:58 Generating 2090 numbers for index: 24
+2024/05/19 23:34:58 Initiating random data generation for index: 25
+2024/05/19 23:34:58 Generating 4957 numbers for index: 25
+2024/05/19 23:34:58 Initiating random data generation for index: 26
+2024/05/19 23:34:58 Initiating random data generation for index: 27
+2024/05/19 23:34:58 Generating 4729 numbers for index: 26
+2024/05/19 23:34:58 Initiating random data generation for index: 28
+2024/05/19 23:34:58 Generating 4231 numbers for index: 28
+2024/05/19 23:34:58 Initiating random data generation for index: 13
+2024/05/19 23:34:58 Generating 3134 numbers for index: 20
+2024/05/19 23:34:58 Initiating random data generation for index: 3
+2024/05/19 23:34:58 Initiating random data generation for index: 4
+2024/05/19 23:34:58 Initiating random data generation for index: 5
+2024/05/19 23:34:58 Initiating random data generation for index: 6
+2024/05/19 23:34:58 Initiating random data generation for index: 7
+2024/05/19 23:34:58 Initiating random data generation for index: 8
+2024/05/19 23:34:58 Initiating random data generation for index: 9
+2024/05/19 23:34:58 Initiating random data generation for index: 10
+2024/05/19 23:34:58 Initiating random data generation for index: 11
+2024/05/19 23:34:58 Initiating random data generation for index: 53
+2024/05/19 23:34:58 Initiating random data generation for index: 46
+2024/05/19 23:34:58 Initiating random data generation for index: 47
+2024/05/19 23:34:58 Initiating random data generation for index: 48
+2024/05/19 23:34:58 Generating 2316 numbers for index: 6
+2024/05/19 23:34:58 Generating 7801 numbers for index: 9
+2024/05/19 23:34:58 Initiating random data generation for index: 16
+2024/05/19 23:34:58 Generating 8393 numbers for index: 16
+2024/05/19 23:34:58 Initiating random data generation for index: 72
+2024/05/19 23:34:58 Generating 5001 numbers for index: 72
+2024/05/19 23:34:58 Initiating random data generation for index: 37
+2024/05/19 23:34:58 Generating 5979 numbers for index: 37
+2024/05/19 23:34:58 Initiating random data generation for index: 49
+2024/05/19 23:34:58 Initiating random data generation for index: 31
+2024/05/19 23:34:58 Initiating random data generation for index: 38
+2024/05/19 23:34:58 Initiating random data generation for index: 39
+2024/05/19 23:34:58 Generating 5801 numbers for index: 51
+2024/05/19 23:34:58 Initiating random data generation for index: 33
+2024/05/19 23:34:58 Initiating random data generation for index: 40
+2024/05/19 23:34:58 Generating 5054 numbers for index: 38
+2024/05/19 23:34:58 Generating 5887 numbers for index: 97
+2024/05/19 23:34:58 Initiating random data generation for index: 41
+2024/05/19 23:34:58 Initiating random data generation for index: 42
+2024/05/19 23:34:58 Generating 58 numbers for index: 42
+2024/05/19 23:34:58 Generating 2412 numbers for index: 4
+2024/05/19 23:34:58 Generating 3384 numbers for index: 3
+2024/05/19 23:34:58 Generating 8487 numbers for index: 5
+2024/05/19 23:34:58 Initiating random data generation for index: 35
+2024/05/19 23:34:58 Initiating random data generation for index: 36
+2024/05/19 23:34:58 Initiating random data generation for index: 59
+2024/05/19 23:34:58 Initiating random data generation for index: 44
+2024/05/19 23:34:58 Generating 9088 numbers for index: 44
+2024/05/19 23:34:58 Generating 963 numbers for index: 59
+2024/05/19 23:34:58 Generating 3800 numbers for index: 41
+2024/05/19 23:34:58 Initiating random data generation for index: 62
+2024/05/19 23:34:58 Generating 3505 numbers for index: 62
+2024/05/19 23:34:58 Initiating random data generation for index: 54
+2024/05/19 23:34:58 Generating 2471 numbers for index: 54
+2024/05/19 23:34:58 Initiating random data generation for index: 60
+2024/05/19 23:34:58 Generating 4206 numbers for index: 60
+2024/05/19 23:34:58 Initiating random data generation for index: 55
+2024/05/19 23:34:58 Generating 1637 numbers for index: 55
+2024/05/19 23:34:58 Initiating random data generation for index: 64
+2024/05/19 23:34:58 Generating 1761 numbers for index: 64
+2024/05/19 23:34:58 Initiating random data generation for index: 56
+2024/05/19 23:34:58 Initiating random data generation for index: 57
+2024/05/19 23:34:58 Generating 6571 numbers for index: 57
+2024/05/19 23:34:58 Initiating random data generation for index: 61
+2024/05/19 23:34:58 Generating 8583 numbers for index: 61
+2024/05/19 23:34:58 Initiating random data generation for index: 63
+2024/05/19 23:34:58 Generating 8055 numbers for index: 63
+2024/05/19 23:34:58 Generating 6579 numbers for index: 52
+2024/05/19 23:34:58 Initiating random data generation for index: 66
+2024/05/19 23:34:58 Initiating random data generation for index: 65
+2024/05/19 23:34:58 Generating 3652 numbers for index: 65
+2024/05/19 23:34:58 Generating 4008 numbers for index: 58
+2024/05/19 23:34:58 Initiating random data generation for index: 71
+2024/05/19 23:34:58 Generating 8364 numbers for index: 71
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_42.txt for index: 42
+2024/05/19 23:34:58 Generating 5085 numbers for index: 66
+2024/05/19 23:34:58 Initiating random data generation for index: 77
+2024/05/19 23:34:58 Generating 3143 numbers for index: 77
+2024/05/19 23:34:58 Initiating random data generation for index: 79
+2024/05/19 23:34:58 Generating 1940 numbers for index: 79
+2024/05/19 23:34:58 Initiating random data generation for index: 78
+2024/05/19 23:34:58 Generating 7607 numbers for index: 78
+2024/05/19 23:34:58 Generating 9263 numbers for index: 75
+2024/05/19 23:34:58 Generating 6554 numbers for index: 80
+2024/05/19 23:34:58 Initiating random data generation for index: 82
+2024/05/19 23:34:58 Generating 8243 numbers for index: 82
+2024/05/19 23:34:58 Initiating random data generation for index: 83
+2024/05/19 23:34:58 Generating 5384 numbers for index: 83
+2024/05/19 23:34:58 Initiating random data generation for index: 86
+2024/05/19 23:34:58 Generating 7921 numbers for index: 86
+2024/05/19 23:34:58 Initiating random data generation for index: 88
+2024/05/19 23:34:58 Generating 5455 numbers for index: 32
+2024/05/19 23:34:58 Generating 2309 numbers for index: 88
+2024/05/19 23:34:58 Initiating random data generation for index: 90
+2024/05/19 23:34:58 Initiating random data generation for index: 91
+2024/05/19 23:34:58 Generating 7638 numbers for index: 91
+2024/05/19 23:34:58 Initiating random data generation for index: 93
+2024/05/19 23:34:58 Generating 6405 numbers for index: 93
+2024/05/19 23:34:58 Generating 7156 numbers for index: 90
+2024/05/19 23:34:58 Initiating random data generation for index: 96
+2024/05/19 23:34:58 Generating 2581 numbers for index: 96
+2024/05/19 23:34:58 Generating 254 numbers for index: 94
+2024/05/19 23:34:58 Initiating random data generation for index: 98
+2024/05/19 23:34:58 Generating 6078 numbers for index: 98
+2024/05/19 23:34:58 Generating 416 numbers for index: 27
+2024/05/19 23:34:58 Generating 5834 numbers for index: 29
+2024/05/19 23:34:58 Generating 705 numbers for index: 13
+2024/05/19 23:34:58 Generating 8848 numbers for index: 10
+2024/05/19 23:34:58 Generating 3214 numbers for index: 48
+2024/05/19 23:34:58 Initiating random data generation for index: 50
+2024/05/19 23:34:58 Generating 4838 numbers for index: 50
+2024/05/19 23:34:58 Generating 1192 numbers for index: 53
+2024/05/19 23:34:58 Generating 624 numbers for index: 46
+2024/05/19 23:34:58 Generating 9275 numbers for index: 47
+2024/05/19 23:34:58 Generating 9461 numbers for index: 85
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_18.txt for index: 18
+2024/05/19 23:34:58 Generating 2061 numbers for index: 14
+2024/05/19 23:34:58 Generating 3940 numbers for index: 11
+2024/05/19 23:34:58 Generating 5021 numbers for index: 8
+2024/05/19 23:34:58 Initiating random data generation for index: 68
+2024/05/19 23:34:58 Generating 4892 numbers for index: 7
+2024/05/19 23:34:58 Initiating random data generation for index: 74
+2024/05/19 23:34:58 Generating 9039 numbers for index: 74
+2024/05/19 23:34:58 Initiating random data generation for index: 69
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:34:58 Generating 4157 numbers for index: 68
+2024/05/19 23:34:58 Generating 6744 numbers for index: 69
+2024/05/19 23:34:58 Generating 4577 numbers for index: 49
+2024/05/19 23:34:58 Generating 4548 numbers for index: 73
+2024/05/19 23:34:58 Generating 6199 numbers for index: 40
+2024/05/19 23:34:58 Initiating random data generation for index: 34
+2024/05/19 23:34:58 Generating 8442 numbers for index: 34
+2024/05/19 23:34:58 Generating 8298 numbers for index: 39
+2024/05/19 23:34:58 Generating 3981 numbers for index: 31
+2024/05/19 23:34:58 Generating 8690 numbers for index: 33
+2024/05/19 23:34:58 Initiating random data generation for index: 84
+2024/05/19 23:34:58 Generating 4498 numbers for index: 84
+2024/05/19 23:34:58 Initiating random data generation for index: 87
+2024/05/19 23:34:58 Generating 1276 numbers for index: 87
+2024/05/19 23:34:58 Generating 6296 numbers for index: 35
+2024/05/19 23:34:58 Generating 3696 numbers for index: 36
+2024/05/19 23:34:58 Initiating random data generation for index: 43
+2024/05/19 23:34:58 Generating 2327 numbers for index: 43
+2024/05/19 23:34:58 Generating 2686 numbers for index: 56
+2024/05/19 23:34:58 Initiating random data generation for index: 76
+2024/05/19 23:34:58 Generating 1508 numbers for index: 76
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_30.txt for index: 30
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_94.txt for index: 94
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_53.txt for index: 53
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_46.txt for index: 46
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_27.txt for index: 27
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_13.txt for index: 13
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_59.txt for index: 59
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_87.txt for index: 87
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_55.txt for index: 55
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_67.txt for index: 67
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_64.txt for index: 64
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_76.txt for index: 76
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_99.txt for index: 99
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_88.txt for index: 88
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_24.txt for index: 24
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_79.txt for index: 79
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_6.txt for index: 6
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_56.txt for index: 56
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_14.txt for index: 14
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_96.txt for index: 96
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_95.txt for index: 95
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_77.txt for index: 77
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_20.txt for index: 20
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_43.txt for index: 43
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_54.txt for index: 54
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_28.txt for index: 28
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_58.txt for index: 58
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_60.txt for index: 60
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_48.txt for index: 48
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_45.txt for index: 45
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_36.txt for index: 36
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_65.txt for index: 65
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_72.txt for index: 72
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_12.txt for index: 12
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_25.txt for index: 25
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_62.txt for index: 62
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_38.txt for index: 38
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_49.txt for index: 49
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_50.txt for index: 50
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_31.txt for index: 31
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_41.txt for index: 41
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_26.txt for index: 26
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_97.txt for index: 97
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_11.txt for index: 11
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_8.txt for index: 8
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_68.txt for index: 68
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_66.txt for index: 66
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_84.txt for index: 84
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_17.txt for index: 17
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_7.txt for index: 7
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_9.txt for index: 9
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_35.txt for index: 35
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_34.txt for index: 34
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_73.txt for index: 73
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_32.txt for index: 32
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_98.txt for index: 98
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_83.txt for index: 83
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_75.txt for index: 75
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_51.txt for index: 51
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_40.txt for index: 40
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_15.txt for index: 15
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_82.txt for index: 82
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_23.txt for index: 23
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_92.txt for index: 92
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_29.txt for index: 29
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_89.txt for index: 89
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_80.txt for index: 80
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_71.txt for index: 71
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_93.txt for index: 93
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_16.txt for index: 16
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_52.txt for index: 52
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_21.txt for index: 21
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_90.txt for index: 90
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_37.txt for index: 37
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_5.txt for index: 5
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_91.txt for index: 91
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_57.txt for index: 57
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_86.txt for index: 86
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_69.txt for index: 69
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_61.txt for index: 61
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_78.txt for index: 78
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_44.txt for index: 44
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_85.txt for index: 85
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_70.txt for index: 70
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_22.txt for index: 22
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_19.txt for index: 19
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_81.txt for index: 81
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_74.txt for index: 74
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_39.txt for index: 39
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_33.txt for index: 33
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_63.txt for index: 63
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_47.txt for index: 47
+2024/05/19 23:34:58 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_10.txt for index: 10
+2024/05/19 23:34:58 ------- Part 2: Mapper intermediate sorter -------
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_13.txt for index: 13
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_54.txt for index: 54
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_99.txt for index: 99
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_21.txt for index: 21
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_99.txt for index: 99
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_14.txt for index: 14
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_55.txt for index: 55
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_20.txt for index: 20
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_77.txt for index: 77
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_6.txt for index: 6
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_7.txt for index: 7
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_8.txt for index: 8
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_94.txt for index: 94
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_83.txt for index: 83
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_44.txt for index: 44
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_19.txt for index: 19
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_75.txt for index: 75
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_77.txt for index: 77
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_94.txt for index: 94
+2024/05/19 23:34:58 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_94.txt for index: 94
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_25.txt for index: 25
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_74.txt for index: 74
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:34:58 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_1.txt for index: 1
+2024/05/19 23:34:58 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_77.txt for index: 77
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_10.txt for index: 10
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_11.txt for index: 11
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_38.txt for index: 38
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_25.txt for index: 25
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_8.txt for index: 8
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_9.txt for index: 9
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_22.txt for index: 22
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_23.txt for index: 23
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_5.txt for index: 5
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_85.txt for index: 85
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_49.txt for index: 49
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_34.txt for index: 34
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_84.txt for index: 84
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_86.txt for index: 86
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_35.txt for index: 35
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_12.txt for index: 12
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_87.txt for index: 87
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_29.txt for index: 29
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_98.txt for index: 98
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_56.txt for index: 56
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_36.txt for index: 36
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_81.txt for index: 81
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_88.txt for index: 88
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_30.txt for index: 30
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_37.txt for index: 37
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_82.txt for index: 82
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_66.txt for index: 66
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_31.txt for index: 31
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_18.txt for index: 18
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_90.txt for index: 90
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_48.txt for index: 48
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_17.txt for index: 17
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_91.txt for index: 91
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_89.txt for index: 89
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_39.txt for index: 39
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_57.txt for index: 57
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_80.txt for index: 80
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_75.txt for index: 75
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_93.txt for index: 93
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_18.txt for index: 18
+2024/05/19 23:34:58 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_18.txt for index: 18
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_6.txt for index: 6
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_51.txt for index: 51
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_87.txt for index: 87
+2024/05/19 23:34:58 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_87.txt for index: 87
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_60.txt for index: 60
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_83.txt for index: 83
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_19.txt for index: 19
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_50.txt for index: 50
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_40.txt for index: 40
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_58.txt for index: 58
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_41.txt for index: 41
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_72.txt for index: 72
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_60.txt for index: 60
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_59.txt for index: 59
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_59.txt for index: 59
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_69.txt for index: 69
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_71.txt for index: 71
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_52.txt for index: 52
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_68.txt for index: 68
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_97.txt for index: 97
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_67.txt for index: 67
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_53.txt for index: 53
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_54.txt for index: 54
+2024/05/19 23:34:58 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_92.txt for index: 92
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_39.txt for index: 39
+2024/05/19 23:34:58 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_13.txt for index: 13
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_80.txt for index: 80
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_52.txt for index: 52
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_16.txt for index: 16
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_32.txt for index: 32
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_28.txt for index: 28
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_45.txt for index: 45
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_78.txt for index: 78
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_79.txt for index: 79
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_61.txt for index: 61
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_26.txt for index: 26
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_46.txt for index: 46
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_62.txt for index: 62
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_27.txt for index: 27
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_73.txt for index: 73
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_89.txt for index: 89
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_4.txt for index: 4
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_64.txt for index: 64
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_42.txt for index: 42
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_15.txt for index: 15
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_43.txt for index: 43
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_42.txt for index: 42
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_42.txt for index: 42
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_24.txt for index: 24
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_96.txt for index: 96
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_14.txt for index: 14
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_12.txt for index: 12
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_8.txt for index: 8
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_52.txt for index: 52
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_9.txt for index: 9
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_76.txt for index: 76
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_55.txt for index: 55
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_63.txt for index: 63
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_59.txt for index: 59
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_47.txt for index: 47
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_7.txt for index: 7
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_78.txt for index: 78
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_64.txt for index: 64
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_64.txt for index: 64
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_49.txt for index: 49
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_66.txt for index: 66
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_9.txt for index: 9
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_33.txt for index: 33
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_27.txt for index: 27
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_46.txt for index: 46
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_27.txt for index: 27
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_46.txt for index: 46
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_54.txt for index: 54
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_78.txt for index: 78
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_75.txt for index: 75
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_95.txt for index: 95
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_55.txt for index: 55
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_70.txt for index: 70
+2024/05/19 23:34:59 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_65.txt for index: 65
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_5.txt for index: 5
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_91.txt for index: 91
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_28.txt for index: 28
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_10.txt for index: 10
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_98.txt for index: 98
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_0.txt for index: 0
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_80.txt for index: 80
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_65.txt for index: 65
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_36.txt for index: 36
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_85.txt for index: 85
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_69.txt for index: 69
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_7.txt for index: 7
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_76.txt for index: 76
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_40.txt for index: 40
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_38.txt for index: 38
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_37.txt for index: 37
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_12.txt for index: 12
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_98.txt for index: 98
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_33.txt for index: 33
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_93.txt for index: 93
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_86.txt for index: 86
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_51.txt for index: 51
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_22.txt for index: 22
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_23.txt for index: 23
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_11.txt for index: 11
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_60.txt for index: 60
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_11.txt for index: 11
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_89.txt for index: 89
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_30.txt for index: 30
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_48.txt for index: 48
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_79.txt for index: 79
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_30.txt for index: 30
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_41.txt for index: 41
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_44.txt for index: 44
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_53.txt for index: 53
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_43.txt for index: 43
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_34.txt for index: 34
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_2.txt for index: 2
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_53.txt for index: 53
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_72.txt for index: 72
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_24.txt for index: 24
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_96.txt for index: 96
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_71.txt for index: 71
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_81.txt for index: 81
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_96.txt for index: 96
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_69.txt for index: 69
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_51.txt for index: 51
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_56.txt for index: 56
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_63.txt for index: 63
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_57.txt for index: 57
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_48.txt for index: 48
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_88.txt for index: 88
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_90.txt for index: 90
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_58.txt for index: 58
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_73.txt for index: 73
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_74.txt for index: 74
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_29.txt for index: 29
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_62.txt for index: 62
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_67.txt for index: 67
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_97.txt for index: 97
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_47.txt for index: 47
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_22.txt for index: 22
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_86.txt for index: 86
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_73.txt for index: 73
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_5.txt for index: 5
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_20.txt for index: 20
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_45.txt for index: 45
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_15.txt for index: 15
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_36.txt for index: 36
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_93.txt for index: 93
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_14.txt for index: 14
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_29.txt for index: 29
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_50.txt for index: 50
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_41.txt for index: 41
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_72.txt for index: 72
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_76.txt for index: 76
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_88.txt for index: 88
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_40.txt for index: 40
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_70.txt for index: 70
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_6.txt for index: 6
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_49.txt for index: 49
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_24.txt for index: 24
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_38.txt for index: 38
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_3.txt for index: 3
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_71.txt for index: 71
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_95.txt for index: 95
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_28.txt for index: 28
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_65.txt for index: 65
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_70.txt for index: 70
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_20.txt for index: 20
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_21.txt for index: 21
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_95.txt for index: 95
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_50.txt for index: 50
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_99.txt for index: 99
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_83.txt for index: 83
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_43.txt for index: 43
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_26.txt for index: 26
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_62.txt for index: 62
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_68.txt for index: 68
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_13.txt for index: 13
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_23.txt for index: 23
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_67.txt for index: 67
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_10.txt for index: 10
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_82.txt for index: 82
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_47.txt for index: 47
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_45.txt for index: 45
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_68.txt for index: 68
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_37.txt for index: 37
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_56.txt for index: 56
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_26.txt for index: 26
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_33.txt for index: 33
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_58.txt for index: 58
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_90.txt for index: 90
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_19.txt for index: 19
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_44.txt for index: 44
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_85.txt for index: 85
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_92.txt for index: 92
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_82.txt for index: 82
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_66.txt for index: 66
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_25.txt for index: 25
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_97.txt for index: 97
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_79.txt for index: 79
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_91.txt for index: 91
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_81.txt for index: 81
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_57.txt for index: 57
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_39.txt for index: 39
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_84.txt for index: 84
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_61.txt for index: 61
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_63.txt for index: 63
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_15.txt for index: 15
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_34.txt for index: 34
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_35.txt for index: 35
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_92.txt for index: 92
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_74.txt for index: 74
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_84.txt for index: 84
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_21.txt for index: 21
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_35.txt for index: 35
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_61.txt for index: 61
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_32.txt for index: 32
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_32.txt for index: 32
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_16.txt for index: 16
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_31.txt for index: 31
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_31.txt for index: 31
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_16.txt for index: 16
+2024/05/19 23:34:59 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_17.txt for index: 17
+2024/05/19 23:34:59 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_17.txt for index: 17
+2024/05/19 23:34:59 ------- Part 3: Reducer final sorter -------
+2024/05/19 23:34:59 Initializing the cursor for all the intermediate sorted files
+[431733687639881 19235439778811845 513865542456461 390200898245508 1304853229203062 545362172246316 3383994824414133 1015735215053841 6456918498050608 2141775829897214 1164974422312618 2094848053794798 773879318341696 1064431333624691 1260413399287754 2253755359486544 728993495438152 5428531522404172 77595254135202553 499431643146347 3238489497372540 1067124935846173 753856128810468 930688939005975 2405381642147139 2391448264228726 1829992736095893 13904532607963632 555500270291838 1710606384334181 39349472287338439 3219623083694286 384780641460104 477176613551094 1622033559648482 936947639668861 1448170324223668 1092058418860379 2076604532115241 27706402301778 499323359104335 5294298541218988 103450689026673624 7425202347677430 24114112002140 4780828113338026 4883628710737258 1168327915365873 788579874808324 5939180205327698 591558573808357 1321487607936540 1959874900966326 4306927539633069 10267785874720047 816641962035784 857456817815181 4717732379536404 2656510634142813 10241017818145388 4183728964210594 1439585580460499 6024007702284069 222487695716873 8157990729336795 980481163356599 1151536084150773 11248997590509527 1257780038087146 234457623568168 856028909518535 275747189982284 359016441505880 2987658749048660 1497018661846126 4531167893761929 24953631040189743 3049381320854574 1338926073464577 4999712638874191 1082918132044192 673218379259109 675417760225892 259320447548775 4374032067992371 49627462010031 617469398298229 1881098693854341 19585617317346765 1248866562827630 3071027371283678 715518883345241 443456151832074 1379483566839748 10429371030895072 4048901692929131 16927721424568330 1829938178461344 1932797274245388 5439984592932733]
+2024/05/19 23:34:59 Initiating the streaming merge sort operation on all the opened file
+2024/05/19 23:35:04 ------- Completed -------
+Execution started at:  2024-05-19T23:34:57+05:30
+Execution ended at:  2024-05-19T23:35:04+05:30
+Execution duration:  6.5223449s
+Initial numbers generated:  490554
+Total entries at final sorted file:  490554

--- a/mapper_reducer_sorter_problem/output_small.txt
+++ b/mapper_reducer_sorter_problem/output_small.txt
@@ -1,0 +1,42 @@
+2024/05/19 23:22:06 ------- Part 1: Generating random numbers -------
+2024/05/19 23:22:06 Initiating random data generation for index: 0
+2024/05/19 23:22:06 Generating 142 numbers for index: 0
+2024/05/19 23:22:06 Initiating random data generation for index: 4
+2024/05/19 23:22:06 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:22:06 Initiating random data generation for index: 1
+2024/05/19 23:22:06 Generating 376 numbers for index: 4
+2024/05/19 23:22:06 Initiating random data generation for index: 2
+2024/05/19 23:22:06 Generating 284 numbers for index: 2
+2024/05/19 23:22:06 Initiating random data generation for index: 3
+2024/05/19 23:22:06 Generating 586 numbers for index: 3
+2024/05/19 23:22:06 Generating 266 numbers for index: 1
+2024/05/19 23:22:06 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:22:06 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:22:06 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:22:06 Storing the random data generated to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:22:06 ------- Part 2: Mapper intermediate sorter -------
+2024/05/19 23:22:06 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:22:06 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:22:06 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:22:06 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:22:06 Reading the intermediate file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:22:06 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_0.txt for index: 0
+2024/05/19 23:22:06 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_0.txt for index: 0
+2024/05/19 23:22:06 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_1.txt for index: 1
+2024/05/19 23:22:06 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_4.txt for index: 4
+2024/05/19 23:22:06 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_3.txt for index: 3
+2024/05/19 23:22:06 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_1.txt for index: 1
+2024/05/19 23:22:06 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_4.txt for index: 4
+2024/05/19 23:22:06 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_3.txt for index: 3
+2024/05/19 23:22:06 Converting and sorting the data read from file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\random_data_generated_2.txt for index: 2
+2024/05/19 23:22:06 Storing the sorted data to file C:\Users\Tisan\Documents\workspace\concurrency problems\mapper_reducer_sorter_problem\operations\intermediate_sorted_data_2.txt for index: 2
+2024/05/19 23:22:06 ------- Part 3: Reducer final sorter -------
+2024/05/19 23:22:06 Initializing the cursor for all the intermediate sorted files
+[2531842027569906 24269847675835834 9732527410741800 773879318341696 1236003032108786]
+2024/05/19 23:22:06 Initiating the streaming merge sort operation on all the opened file
+2024/05/19 23:22:06 ------- Completed -------
+Execution started at:  2024-05-19T23:22:06+05:30
+Execution ended at:  2024-05-19T23:22:06+05:30
+Execution duration:  473.6836ms
+Initial numbers generated:  1654
+Total entries at final sorted file:  1654

--- a/mapper_reducer_sorter_problem/storage/file_system.go
+++ b/mapper_reducer_sorter_problem/storage/file_system.go
@@ -1,0 +1,106 @@
+package storage
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+)
+
+type FileSystem struct {
+	fileName          string
+	openedFile        *os.File
+	openedFileScanner *bufio.Scanner
+}
+
+func NewFileSystem(fileName string) File {
+	return &FileSystem{
+		fileName:          fileName,
+		openedFile:        nil,
+		openedFileScanner: nil,
+	}
+}
+
+func (file *FileSystem) Open() error {
+	// no-op
+	return nil
+}
+
+func (file *FileSystem) Close() error {
+	// no-op
+	file.openedFile.Close()
+	return nil
+}
+
+func (file *FileSystem) Read(int, int) (string, error) {
+	openedFile, err := os.OpenFile(file.fileName, os.O_RDONLY, 0600)
+	if err != nil {
+		return "", fmt.Errorf("Error occurred while opening file %s: %s", file.fileName, err)
+	}
+	defer openedFile.Close()
+	var buffer bytes.Buffer
+	_, err = buffer.ReadFrom(openedFile)
+	if err != nil {
+		return "", fmt.Errorf("Error occurred while writing the content to file %s : %s", file.fileName, err)
+	}
+	return buffer.String(), nil
+
+}
+
+func (file *FileSystem) ReadNextLine(int, int) (string, error) {
+	if file.openedFile == nil {
+		openedFile, err := os.OpenFile(file.fileName, os.O_RDONLY, 0600)
+		if err != nil {
+			return "", fmt.Errorf("Error occurred while opening file %s: %s", file.fileName, err)
+		}
+		file.openedFile = openedFile
+		scanner := bufio.NewScanner(openedFile)
+		file.openedFileScanner = scanner
+	}
+	if file.openedFileScanner.Scan() {
+		return file.openedFileScanner.Text(), nil
+	} else {
+		return "", nil
+	}
+}
+
+func (file *FileSystem) Write(offset int, content string) error {
+	openedFile, err := os.OpenFile(file.fileName, os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return fmt.Errorf("Error occurred while opening file %s: %s", file.fileName, err)
+	}
+	defer openedFile.Close()
+	buffer := []byte(content)
+	_, err = openedFile.WriteAt(buffer, int64(offset))
+	if err != nil {
+		return fmt.Errorf("Error occurred while writing to file %s: %s", file.fileName, err)
+	}
+	return nil
+}
+
+func (file *FileSystem) Append(content string) error {
+
+	if file.openedFile == nil {
+		openedFile, err := os.OpenFile(file.fileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+		if err != nil {
+			return fmt.Errorf("Error occurred while opening file %s: %s", file.fileName, err)
+		}
+		file.openedFile = openedFile
+	}
+	_, err := file.openedFile.WriteString(content)
+	if err != nil {
+		return fmt.Errorf("Error occurred while writing the content to file %s : %s", file.fileName, err)
+	}
+	return nil
+
+	// openedFile, err := os.OpenFile(file.fileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	// if err != nil {
+	// 	return fmt.Errorf("Error occurred while opening file %s: %s", file.fileName, err)
+	// }
+	// defer openedFile.Close()
+	// _, err = openedFile.WriteString(content)
+	// if err != nil {
+	// 	return fmt.Errorf("Error occurred while writing the content to file %s : %s", file.fileName, err)
+	// }
+	// return nil
+}

--- a/mapper_reducer_sorter_problem/storage/storage.go
+++ b/mapper_reducer_sorter_problem/storage/storage.go
@@ -1,0 +1,10 @@
+package storage
+
+type File interface {
+	Open() error
+	Close() error
+	Read(int, int) (string, error)
+	Write(int, string) error
+	Append(string) error
+	ReadNextLine(int, int) (string, error)
+}


### PR DESCRIPTION
#### This PR is created to handle the following scenarios:
- Added a rudimentary implementation of mapper-reducer to sort list of randomly generated integers
    - Couple of integers are randomly generated on batch and stored on files with prefix ```random_data_generated_<i>.txt```
    - The mapper function would pick up such randomly generated data from file, and would sort them and store then on files with prefix ```intermediate_sorted_data_<i>.txt```
    - The reducer method would perform a final sorting from the above generated intermediate sorted files and stores the final generated output on the file ```final_sorted_data.txt```